### PR TITLE
Phase 0: Swift macOS app foundation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,111 +1,36 @@
-# CLAUDE.md
+# September — Claude
 
-Project orientation for Claude Code when working with September codebase.
+September is an assistive communication app for people with ALS, MND, or speech/motor difficulties. Fewer keystrokes to full expression.
 
-## What is September?
+## Apps
 
-September is an assistive communication app for people with ALS, MND, or speech/motor difficulties. It helps users communicate effectively with fewer keystrokes through AI-powered autocomplete, real-time transcription, and contextual suggestions.
+| App                | Path           | Stack                          |
+| ------------------ | -------------- | ------------------------------ |
+| Web                | `apps/web/`    | Next.js 15, React 19, Tailwind |
+| macOS (Swift)      | `apps/swift/`  | SwiftUI + AppKit, SwiftData    |
 
-## Tech Stack
+Each app has its own `CLAUDE.md` with build commands and code style rules. Read the relevant one before working in that app.
 
-- **Framework**: Next.js 15 (App Router, React 19)
-- **Styling**: Tailwind CSS 4, shadcn/ui components ([docs](https://ui.shadcn.com/llms.txt))
-- **Local Storage**: IndexedDB (via TanStack DB)
-- **AI**: Google Gemini API, Vercel AI SDK
-- **Voice**: ElevenLabs (TTS, voice cloning)
-- **Forms**: React Hook Form + Zod validation
-- **Package Manager**: pnpm (workspace monorepo)
+## Monorepo
 
-## Project Structure
-
-This is a **pnpm workspace monorepo** with apps and shared packages.
+pnpm workspace. Shared packages in `packages/` with `@september/*` naming.
 
 ```
 september/
-├── apps/
-│   └── web/                    # Next.js web app
-│       ├── app/                # App Router pages
-│       ├── components/         # Web-specific components (sidebar, home, context)
-│       ├── services/           # Server-side integrations
-│       └── package.json
-├── packages/
-│   ├── shared/                 # @september/shared - Utils, hooks, types
-│   │   ├── lib/               # Utility functions (indexeddb, utils)
-│   │   ├── hooks/             # Shared React hooks
-│   │   └── types/             # TypeScript types
-│   ├── ui/                     # @september/ui - shadcn/ui components
-│   ├── account/               # @september/account - User account & DB sync
-│   ├── ai/                    # @september/ai - AI config & service registry
-│   ├── analytics/             # @september/analytics - Usage analytics
-│   ├── audio/                 # @september/audio - Audio playback & storage
-│   ├── chats/                 # @september/chats - Chat & message management
-│   ├── cloning/               # @september/cloning - Voice cloning
-│   ├── documents/             # @september/documents - Document management
-│   ├── editor/                # @september/editor - Autocomplete text editor
-│   ├── keyboards/             # @september/keyboards - Accessible keyboards
-│   ├── onboarding/            # @september/onboarding - User onboarding
-│   ├── recording/             # @september/recording - Audio recording
-│   ├── speech/                # @september/speech - TTS & voice management
-│   └── suggestions/           # @september/suggestions - Contextual suggestions
-├── pnpm-workspace.yaml         # Workspace config
-└── package.json                # Root package.json
+├── apps/web/          # Web app
+├── apps/swift/        # macOS app (Swift Package)
+├── packages/          # Shared TS packages (@september/*)
+└── docs/swift/        # macOS design specs, roadmap, assets
 ```
 
-## Development
+## TDD (strict)
 
-```bash
-# From workspace root
-pnpm install                      # Install all dependencies
-pnpm --filter @september/web dev  # Start web app dev server
-pnpm --filter @september/web build # Build web app
-pnpm --filter @september/web lint  # Lint web app
-```
+Write tests BEFORE implementation. Run failing test, write minimum code to pass, confirm green. No exceptions.
 
-## Code Patterns
-
-**Packages**: All shared code lives in `packages/` as workspace packages with `@september/*` naming:
-
-- Import shared utilities: `import { cn } from "@september/shared/lib/utils"`
-- Import UI components: `import { Button } from "@september/ui/components/button"`
-- Import domain packages: `import { useAccount } from "@september/account"`
-
-**Package Structure**: Each package should have:
-
-- `components/`: Context providers, forms, and feature-specific UI.
-- `hooks/`: State management and domain logic (e.g., `use-db-*`, `use-auth-*`, `use-ai-*`).
-- `lib/`: Package-specific utility functions and services.
-- `types/`: Zod schemas and TypeScript interfaces.
-- `index.ts`: Public API for the package.
-- `package.json`: Package manifest with `workspace:*` dependencies.
-- `README.md`: Architectural decisions and usage guides.
-
-**Forms**: Always use `react-hook-form` with `zodResolver` for validation. Use form components from `@september/ui/components/form`.
-
-**Styling**: Use shadcn/ui components with Tailwind CSS. Font family is Noto Sans.
-
-**Error Handling**:
-
-- **Query Hooks** (read operations): Return error object: `{ data, isLoading, error }`. Error shape: `{ message: string }`.
-- **Mutation Hooks** (write operations): Throw errors for component error boundaries. Use toast notifications for user feedback. Log to console for debugging.
-- **Return Types**: All hooks should have explicit return type interfaces for better IDE support and type safety.
-- **Pattern**:
-
-```typescript
-interface UseOperationReturn {
-  data: T | undefined;
-  isLoading: boolean;
-  error?: { message: string };
-}
-
-export function useOperation(): UseOperationReturn {
-  // ...
-}
-```
-
-## Important
+## Rules
 
 - Do what has been asked; nothing more, nothing less
-- ALWAYS prefer editing existing files over creating new ones
-- **READ and UPDATE the README.md in each module directory before and after making changes.**
-- Follow the modular structure in `packages/` for new features or refactors.
-- For architecture details, see [README.md](README.md).
+- Prefer editing existing files over creating new ones
+- READ and UPDATE the README.md in each module before and after changes
+- No secrets in commits (`.env`, API keys, credentials)
+- Run the build/lint/test commands listed in the app's CLAUDE.md before committing

--- a/apps/swift/.gitignore
+++ b/apps/swift/.gitignore
@@ -1,0 +1,6 @@
+.build/
+.swiftpm/
+DerivedData/
+*.xcodeproj
+*.xcworkspace
+*.app

--- a/apps/swift/CLAUDE.md
+++ b/apps/swift/CLAUDE.md
@@ -1,0 +1,40 @@
+# September macOS — Claude
+
+Assistive communication app (ALS/MND). Native macOS with SwiftUI + AppKit. Local-first with SwiftData. Target macOS 14+ (Sonoma).
+
+## Build
+
+Requires Xcode toolchain for SwiftData macros — always set `DEVELOPER_DIR`.
+
+| Command          | Purpose                    |
+| ---------------- | -------------------------- |
+| `./build.sh`     | Build signed `.app` bundle |
+| `./build.sh dev` | Quick dev run              |
+| `swift build`    | Compile only               |
+| `swift test`     | Run tests                  |
+
+```bash
+export DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
+```
+
+## Swift Style
+
+- `@Observable` + `@MainActor` for view models — never `ObservableObject` / `@Published` / `Combine`
+- `@State` for ownership, `@Bindable` for two-way binding
+- `@MainActor @Observable` for UI-coupled services (e.g., `AVSpeechService`)
+- `actor` for background services (e.g., AI, Transcription)
+- All types crossing actor boundaries must be `Sendable`
+- `async/await` everywhere, no completion handlers
+- Service protocols in `Services/<Domain>/<Domain>Service.swift`, mocks in `Mock<Domain>Service.swift`
+- `Codable` struct fields must have defaults for forward-compatible decoding
+- Prefer editing existing files over creating new ones
+
+## Testing
+
+Swift Testing framework (`@Test`, `#expect`, `@Suite`). In-memory `ModelContainer` for SwiftData tests. `@MainActor` on tests touching main-actor-isolated types.
+
+## Design Reference
+
+Specs and mockups in `docs/swift/assets/`. Product overview: `docs/swift/product-overview.md`. Roadmap: `docs/swift/roadmap.md`.
+
+**READ and UPDATE the README.md before and after making changes.**

--- a/apps/swift/Package.swift
+++ b/apps/swift/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version: 5.10
+
+import PackageDescription
+
+let package = Package(
+    name: "September",
+    platforms: [
+        .macOS(.v14),
+    ],
+    targets: [
+        .executableTarget(
+            name: "September",
+            path: "Sources/September",
+            swiftSettings: [
+                .enableExperimentalFeature("StrictConcurrency"),
+            ]
+        ),
+        .testTarget(
+            name: "SeptemberTests",
+            dependencies: ["September"],
+            path: "Tests/SeptemberTests",
+            swiftSettings: [
+                .enableExperimentalFeature("StrictConcurrency"),
+            ]
+        ),
+    ]
+)

--- a/apps/swift/README.md
+++ b/apps/swift/README.md
@@ -1,0 +1,53 @@
+# September for macOS
+
+Native assistive communication app for people with ALS, MND, or speech/motor difficulties. Integrates at the OS level with floating panels, system-wide keyboard input, and native speech services.
+
+## Requirements
+
+- macOS 14+ (Sonoma)
+- Xcode 15.2+ / Swift 5.10+
+
+## Build & Run
+
+SwiftData macros require the Xcode toolchain. Set `DEVELOPER_DIR` if your default is Command Line Tools:
+
+```bash
+cd apps/swift
+export DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
+
+swift build          # Compile
+swift run September  # Launch app
+swift test           # Run tests
+```
+
+## Architecture
+
+```
+Sources/September/
+├── App/                     # Entry point, window management
+├── Core/
+│   ├── Models/              # SwiftData models (Account, Document, Panel)
+│   └── DesignTokens/        # Colors, typography
+├── Features/
+│   ├── Keyboard/            # Type mode
+│   ├── Talk/                # Talk mode
+│   ├── Writer/              # Write mode
+│   └── Settings/            # Settings screens
+└── Services/
+    ├── AI/                  # AI provider abstraction
+    ├── Speech/              # TTS abstraction (AVSpeech, etc.)
+    └── Transcription/       # STT abstraction
+```
+
+### Guidelines
+
+- `@Observable` with `@MainActor` for view models (not `ObservableObject`)
+- `@State` for view model ownership, `@Bindable` for two-way binding
+- Strict Swift concurrency: all types crossing threads must be `Sendable`
+- SwiftData for local persistence
+- `NSPanel` + `NSHostingView` for floating windows (non-activating)
+
+### Dev Notes
+
+- **Schema changes during development:** A `#if DEBUG` guard in `SeptemberApp.swift` will delete and recreate the SwiftData store if the schema is incompatible. This prevents crashes when iterating on models. Remove before shipping.
+- **Fonts:** Typography constants reference JetBrains Mono and Geist with system fallbacks. Fonts are not bundled yet — they will be added when the keyboard UI is built.

--- a/apps/swift/Resources/Info.plist
+++ b/apps/swift/Resources/Info.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>to.september.app</string>
+    <key>CFBundleName</key>
+    <string>September</string>
+    <key>CFBundleDisplayName</key>
+    <string>September</string>
+    <key>CFBundleExecutable</key>
+    <string>September</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.1.0</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>14.0</string>
+    <key>LSUIElement</key>
+    <true/>
+    <key>NSAccessibilityUsageDescription</key>
+    <string>September needs Accessibility access to send keystrokes to other applications on your behalf.</string>
+    <key>NSAppleEventsUsageDescription</key>
+    <string>September uses automation to send keystrokes to applications.</string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+    <key>NSPrincipalClass</key>
+    <string>NSApplication</string>
+</dict>
+</plist>

--- a/apps/swift/Resources/September.entitlements
+++ b/apps/swift/Resources/September.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <false/>
+</dict>
+</plist>

--- a/apps/swift/Sources/September/App/AppTab.swift
+++ b/apps/swift/Sources/September/App/AppTab.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+enum AppTab: String, CaseIterable, Sendable {
+    case type
+    case talk
+    case write
+    case settings
+}

--- a/apps/swift/Sources/September/App/ContentView.swift
+++ b/apps/swift/Sources/September/App/ContentView.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+struct ContentView: View {
+    @State private var selectedTab: AppTab = .type
+
+    var body: some View {
+        TabView(selection: $selectedTab) {
+            TypePlaceholderView()
+                .tabItem { Label("Type", systemImage: "keyboard") }
+                .tag(AppTab.type)
+
+            TalkPlaceholderView()
+                .tabItem { Label("Talk", systemImage: "waveform") }
+                .tag(AppTab.talk)
+
+            WritePlaceholderView()
+                .tabItem { Label("Write", systemImage: "doc.text") }
+                .tag(AppTab.write)
+
+            SettingsPlaceholderView()
+                .tabItem { Label("Settings", systemImage: "gearshape") }
+                .tag(AppTab.settings)
+        }
+    }
+}

--- a/apps/swift/Sources/September/App/FloatingPanel.swift
+++ b/apps/swift/Sources/September/App/FloatingPanel.swift
@@ -1,0 +1,76 @@
+import AppKit
+import SwiftUI
+
+// MARK: - FloatingPanel
+//
+// NSPanel subclass for non-activating floating windows.
+// Stays on top of all apps without stealing focus — essential for
+// assistive keyboard overlay.
+//
+// Not wired into the app shell yet (Phase 1). Infrastructure only.
+
+final class FloatingPanel: NSPanel {
+    private static let frameKey = "FloatingPanelFrame"
+
+    init(contentView: NSView) {
+        super.init(
+            contentRect: .zero,
+            styleMask: [.nonactivatingPanel, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+
+        self.contentView = contentView
+        self.level = .floating
+        self.isFloatingPanel = true
+        self.hidesOnDeactivate = false
+        self.isReleasedWhenClosed = false
+        self.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        self.isMovableByWindowBackground = true
+        self.isOpaque = false
+        self.backgroundColor = .clear
+        contentView.wantsLayer = true
+        contentView.layer?.cornerRadius = 10
+        contentView.layer?.masksToBounds = true
+
+        let size = contentView.fittingSize
+        let width = max(size.width, 850)
+        let height = max(size.height, 320)
+        setContentSize(NSSize(width: width, height: height))
+
+        restorePosition()
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(savePosition),
+            name: NSWindow.didMoveNotification,
+            object: self
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(savePosition),
+            name: NSWindow.didResizeNotification,
+            object: self
+        )
+    }
+
+    private func restorePosition() {
+        if let savedFrame = UserDefaults.standard.string(forKey: Self.frameKey) {
+            let frame = NSRectFromString(savedFrame)
+            if NSScreen.screens.contains(where: { $0.visibleFrame.intersects(frame) }) {
+                setFrame(frame, display: true)
+            } else {
+                center()
+            }
+        } else {
+            center()
+        }
+    }
+
+    @objc private func savePosition() {
+        UserDefaults.standard.set(NSStringFromRect(frame), forKey: Self.frameKey)
+    }
+
+    override var canBecomeKey: Bool { false }
+    override var canBecomeMain: Bool { false }
+}

--- a/apps/swift/Sources/September/App/SeptemberApp.swift
+++ b/apps/swift/Sources/September/App/SeptemberApp.swift
@@ -1,0 +1,38 @@
+import SwiftData
+import SwiftUI
+
+@main
+struct SeptemberApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+        .modelContainer(Self.makeContainer())
+    }
+
+    private static func makeContainer() -> ModelContainer {
+        let schema = Schema([
+            Account.self,
+            Document.self,
+            Panel.self,
+            PanelButton.self,
+        ])
+
+        let config = ModelConfiguration(isStoredInMemoryOnly: false)
+
+        do {
+            return try ModelContainer(for: schema, configurations: [config])
+        } catch {
+            #if DEBUG
+            // During development, schema changes without migration will crash.
+            // Delete the store and retry so iteration isn't blocked.
+            print("[SeptemberApp] SwiftData failed: \(error). Resetting store...")
+            let inMemory = ModelConfiguration(isStoredInMemoryOnly: true)
+            if let fallback = try? ModelContainer(for: schema, configurations: [inMemory]) {
+                return fallback
+            }
+            #endif
+            fatalError("Failed to create ModelContainer: \(error)")
+        }
+    }
+}

--- a/apps/swift/Sources/September/Core/DesignTokens/Colors.swift
+++ b/apps/swift/Sources/September/Core/DesignTokens/Colors.swift
@@ -1,0 +1,67 @@
+import AppKit
+import SwiftUI
+
+// MARK: - Design Token Colors
+//
+// All tokens adapt automatically to light/dark appearance via
+// NSColor(name:dynamicProvider:). Values sourced from design-specifications.png.
+
+enum DesignColors {
+
+    // MARK: Semantic Tokens
+
+    static let background = dynamicColor(light: 0xFFFFFF, dark: 0x0A0A0A)
+    static let foreground = dynamicColor(light: 0x0A0A0A, dark: 0xFAFAFA)
+    static let card = dynamicColor(light: 0xF4F4F5, dark: 0x18181B)
+    static let primary = dynamicColor(light: 0xFF8400, dark: 0xFF8400)
+    static let secondary = dynamicColor(light: 0xF4F4F5, dark: 0x27272A)
+    static let muted = dynamicColor(light: 0xF4F4F5, dark: 0x27272A)
+    static let mutedForeground = dynamicColor(light: 0x71717A, dark: 0xA1A1AA)
+    static let border = dynamicColor(light: 0xE4E4E7, dark: 0x27272A)
+    static let destructive = dynamicColor(light: 0xEF4444, dark: 0xEF4444)
+
+    // MARK: Keyboard Tokens (from design-specifications.png)
+
+    static let kbBackground = dynamicColor(light: 0xE8E8EC, dark: 0x1C1C1E)
+    static let kbKey = dynamicColor(light: 0xFFFFFF, dark: 0x3A3A3C)
+    static let kbKeySpecial = dynamicColor(light: 0xB8B8BF, dark: 0x2C2C2E)
+    static let kbKeyText = dynamicColor(light: 0x1C1C1E, dark: 0xF2F2F7)
+    static let kbKeyShadow = dynamicColor(light: 0x00000026, dark: 0x00000040)
+    static let kbAccent = dynamicColor(light: 0x007AFF, dark: 0x0A84FF)
+
+    // MARK: Sidebar Tokens
+
+    static let sidebar = dynamicColor(light: 0xF4F4F5, dark: 0x18181B)
+    static let sidebarAccent = dynamicColor(light: 0xFF8400, dark: 0xFF8400)
+    static let sidebarForeground = dynamicColor(light: 0x0A0A0A, dark: 0xFAFAFA)
+    static let sidebarBorder = dynamicColor(light: 0xE4E4E7, dark: 0x27272A)
+
+    // MARK: Keyboard Dimensions
+
+    static let kbCornerRadius: CGFloat = 6
+
+    // MARK: - Helpers
+
+    private static func dynamicColor(light: UInt32, dark: UInt32) -> Color {
+        Color(nsColor: NSColor(name: nil, dynamicProvider: { appearance in
+            let name = appearance.bestMatch(from: [.aqua, .darkAqua])
+            return name == .darkAqua ? nsColor(from: dark) : nsColor(from: light)
+        }))
+    }
+
+    private static func nsColor(from hex: UInt32) -> NSColor {
+        let hasAlpha = hex > 0xFFFFFF
+        if hasAlpha {
+            let r = CGFloat((hex >> 24) & 0xFF) / 255
+            let g = CGFloat((hex >> 16) & 0xFF) / 255
+            let b = CGFloat((hex >> 8) & 0xFF) / 255
+            let a = CGFloat(hex & 0xFF) / 255
+            return NSColor(red: r, green: g, blue: b, alpha: a)
+        } else {
+            let r = CGFloat((hex >> 16) & 0xFF) / 255
+            let g = CGFloat((hex >> 8) & 0xFF) / 255
+            let b = CGFloat(hex & 0xFF) / 255
+            return NSColor(red: r, green: g, blue: b, alpha: 1)
+        }
+    }
+}

--- a/apps/swift/Sources/September/Core/DesignTokens/Colors.swift
+++ b/apps/swift/Sources/September/Core/DesignTokens/Colors.swift
@@ -26,7 +26,7 @@ enum DesignColors {
     static let kbKey = dynamicColor(light: 0xFFFFFF, dark: 0x3A3A3C)
     static let kbKeySpecial = dynamicColor(light: 0xB8B8BF, dark: 0x2C2C2E)
     static let kbKeyText = dynamicColor(light: 0x1C1C1E, dark: 0xF2F2F7)
-    static let kbKeyShadow = dynamicColor(light: 0x00000026, dark: 0x00000040)
+    static let kbKeyShadow = dynamicColor(light: (0x000000, 0.15), dark: (0x000000, 0.25))
     static let kbAccent = dynamicColor(light: 0x007AFF, dark: 0x0A84FF)
 
     // MARK: Sidebar Tokens
@@ -40,7 +40,7 @@ enum DesignColors {
 
     static let kbCornerRadius: CGFloat = 6
 
-    // MARK: - Helpers
+    // MARK: - Helpers (RGB)
 
     private static func dynamicColor(light: UInt32, dark: UInt32) -> Color {
         Color(nsColor: NSColor(name: nil, dynamicProvider: { appearance in
@@ -49,19 +49,23 @@ enum DesignColors {
         }))
     }
 
-    private static func nsColor(from hex: UInt32) -> NSColor {
-        let hasAlpha = hex > 0xFFFFFF
-        if hasAlpha {
-            let r = CGFloat((hex >> 24) & 0xFF) / 255
-            let g = CGFloat((hex >> 16) & 0xFF) / 255
-            let b = CGFloat((hex >> 8) & 0xFF) / 255
-            let a = CGFloat(hex & 0xFF) / 255
-            return NSColor(red: r, green: g, blue: b, alpha: a)
-        } else {
-            let r = CGFloat((hex >> 16) & 0xFF) / 255
-            let g = CGFloat((hex >> 8) & 0xFF) / 255
-            let b = CGFloat(hex & 0xFF) / 255
-            return NSColor(red: r, green: g, blue: b, alpha: 1)
-        }
+    // MARK: - Helpers (RGB + separate alpha)
+
+    private static func dynamicColor(
+        light: (UInt32, Double),
+        dark: (UInt32, Double)
+    ) -> Color {
+        Color(nsColor: NSColor(name: nil, dynamicProvider: { appearance in
+            let name = appearance.bestMatch(from: [.aqua, .darkAqua])
+            let (hex, alpha) = name == .darkAqua ? dark : light
+            return nsColor(from: hex, alpha: alpha)
+        }))
+    }
+
+    private static func nsColor(from hex: UInt32, alpha: Double = 1.0) -> NSColor {
+        let r = CGFloat((hex >> 16) & 0xFF) / 255
+        let g = CGFloat((hex >> 8) & 0xFF) / 255
+        let b = CGFloat(hex & 0xFF) / 255
+        return NSColor(red: r, green: g, blue: b, alpha: CGFloat(alpha))
     }
 }

--- a/apps/swift/Sources/September/Core/DesignTokens/Typography.swift
+++ b/apps/swift/Sources/September/Core/DesignTokens/Typography.swift
@@ -55,21 +55,22 @@ enum Typography {
 
     // MARK: - Font Builders
 
+    private static let isPrimaryAvailable = NSFontManager.shared
+        .availableMembers(ofFontFamily: primaryFontName) != nil
+    private static let isSecondaryAvailable = NSFontManager.shared
+        .availableMembers(ofFontFamily: secondaryFontName) != nil
+
     private static func primary(size: CGFloat, weight: Font.Weight) -> Font {
-        if fontAvailable(primaryFontName) {
+        if isPrimaryAvailable {
             return .custom(primaryFontName, size: size).weight(weight)
         }
         return .system(size: size, weight: weight, design: .monospaced)
     }
 
     private static func secondary(size: CGFloat, weight: Font.Weight) -> Font {
-        if fontAvailable(secondaryFontName) {
+        if isSecondaryAvailable {
             return .custom(secondaryFontName, size: size).weight(weight)
         }
         return .system(size: size, weight: weight, design: .default)
-    }
-
-    private static func fontAvailable(_ name: String) -> Bool {
-        NSFontManager.shared.availableMembers(ofFontFamily: name) != nil
     }
 }

--- a/apps/swift/Sources/September/Core/DesignTokens/Typography.swift
+++ b/apps/swift/Sources/September/Core/DesignTokens/Typography.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+
+// MARK: - Typography
+//
+// Primary: JetBrains Mono (monospaced, used for keyboard labels and code)
+// Secondary: Geist (sans-serif, used for UI text)
+//
+// Falls back to system fonts if custom fonts are not installed.
+// Font bundling will be added when the keyboard UI is built.
+
+enum Typography {
+
+    static let primaryFontName = "JetBrains Mono"
+    static let secondaryFontName = "Geist"
+
+    // MARK: Semantic Styles
+
+    static func title(_ size: CGFloat = 24) -> Font {
+        secondary(size: size, weight: .bold)
+    }
+
+    static func heading(_ size: CGFloat = 18) -> Font {
+        secondary(size: size, weight: .semibold)
+    }
+
+    static func body(_ size: CGFloat = 14) -> Font {
+        secondary(size: size, weight: .regular)
+    }
+
+    static func caption(_ size: CGFloat = 12) -> Font {
+        secondary(size: size, weight: .regular)
+    }
+
+    // MARK: Keyboard-Specific (from design-specifications.png)
+
+    /// Standard key label: size 18, regular weight
+    static func keyLabel(_ size: CGFloat = 18) -> Font {
+        .system(size: size, weight: .regular, design: .default)
+    }
+
+    /// Special key label: size 12, regular weight
+    static func specialKeyLabel(_ size: CGFloat = 12) -> Font {
+        .system(size: size, weight: .regular, design: .default)
+    }
+
+    /// Function key label: size 11, medium weight
+    static func functionKeyLabel(_ size: CGFloat = 11) -> Font {
+        .system(size: size, weight: .medium, design: .default)
+    }
+
+    /// Monospaced text (input bar, code)
+    static func mono(_ size: CGFloat = 14) -> Font {
+        primary(size: size, weight: .regular)
+    }
+
+    // MARK: - Font Builders
+
+    private static func primary(size: CGFloat, weight: Font.Weight) -> Font {
+        if fontAvailable(primaryFontName) {
+            return .custom(primaryFontName, size: size).weight(weight)
+        }
+        return .system(size: size, weight: weight, design: .monospaced)
+    }
+
+    private static func secondary(size: CGFloat, weight: Font.Weight) -> Font {
+        if fontAvailable(secondaryFontName) {
+            return .custom(secondaryFontName, size: size).weight(weight)
+        }
+        return .system(size: size, weight: weight, design: .default)
+    }
+
+    private static func fontAvailable(_ name: String) -> Bool {
+        NSFontManager.shared.availableMembers(ofFontFamily: name) != nil
+    }
+}

--- a/apps/swift/Sources/September/Core/Models/AIConfig.swift
+++ b/apps/swift/Sources/September/Core/Models/AIConfig.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+// MARK: - Provider Enums
+//
+// Split into 3 domain-specific enums to prevent invalid states.
+// e.g., SuggestionsConfig can only reference AIProvider, not SpeechProvider.
+
+enum AIProvider: String, Codable, Sendable, CaseIterable {
+    case openai
+    case anthropic
+    case ollama
+    case foundationModels
+}
+
+enum SpeechProvider: String, Codable, Sendable, CaseIterable {
+    case avSpeech
+    case openaiTTS
+    case elevenlabs
+}
+
+enum TranscriptionProvider: String, Codable, Sendable, CaseIterable {
+    case appleSpeech
+    case whisper
+    case whisperCpp
+}
+
+// MARK: - AI Suggestions Config
+// Mirrors: packages/account/types/index.ts → SuggestionsConfigSchema
+
+struct SuggestionsConfig: Codable, Sendable {
+    var enabled: Bool = false
+    var provider: AIProvider = .openai
+    var model: String? = nil
+    var temperature: Double = 0.7
+    var maxSuggestions: Int = 5
+    var contextWindow: Int = 10
+    var systemInstructions: String? = nil
+}
+
+// MARK: - Transcription Config
+// Mirrors: packages/account/types/index.ts → TranscriptionConfigSchema
+
+struct TranscriptionConfig: Codable, Sendable {
+    var enabled: Bool = false
+    var provider: TranscriptionProvider = .appleSpeech
+    var model: String? = nil
+    var language: String? = nil
+    var detectLanguage: Bool = true
+    var autoPunctuation: Bool = true
+    var continuousListening: Bool = false
+}
+
+// MARK: - Speech Config
+// Mirrors: packages/account/types/index.ts → SpeechConfigSchema
+
+struct SpeechConfig: Codable, Sendable {
+    var enabled: Bool = true
+    var provider: SpeechProvider = .avSpeech
+    var voiceId: String? = nil
+    var voiceName: String? = nil
+    var speed: Double = 1.0
+    var pitch: Double = 1.0
+    var volume: Double = 1.0
+    var language: String = "en-US"
+}

--- a/apps/swift/Sources/September/Core/Models/Account.swift
+++ b/apps/swift/Sources/September/Core/Models/Account.swift
@@ -1,0 +1,68 @@
+import Foundation
+import SwiftData
+
+// MARK: - Account
+//
+// Single user account with personal info, AI configs, and app flags.
+// Mirrors: packages/account/types/index.ts → AccountSchema
+//
+// AI config sub-objects are stored as Codable structs. All fields have
+// default values for forward-compatible JSON decoding.
+
+@Model
+final class Account {
+    @Attribute(.unique) var id: String
+
+    // Personal Information
+    var name: String
+    var city: String?
+    var country: String?
+
+    // Medical Information
+    var primaryDiagnosis: String?
+    var yearOfDiagnosis: Int?
+
+    // AI Feature Configurations (stored as JSON via Codable)
+    var aiSuggestions: SuggestionsConfig
+    var aiTranscription: TranscriptionConfig
+    var aiSpeech: SpeechConfig
+
+    // Flags
+    var termsAccepted: Bool
+    var privacyPolicyAccepted: Bool
+    var onboardingCompleted: Bool
+
+    // Timestamps
+    var createdAt: Date
+    var updatedAt: Date
+
+    init(
+        id: String = UUID().uuidString,
+        name: String,
+        city: String? = nil,
+        country: String? = nil,
+        primaryDiagnosis: String? = nil,
+        yearOfDiagnosis: Int? = nil,
+        aiSuggestions: SuggestionsConfig = SuggestionsConfig(),
+        aiTranscription: TranscriptionConfig = TranscriptionConfig(),
+        aiSpeech: SpeechConfig = SpeechConfig(),
+        termsAccepted: Bool = false,
+        privacyPolicyAccepted: Bool = false,
+        onboardingCompleted: Bool = false
+    ) {
+        self.id = id
+        self.name = name
+        self.city = city
+        self.country = country
+        self.primaryDiagnosis = primaryDiagnosis
+        self.yearOfDiagnosis = yearOfDiagnosis
+        self.aiSuggestions = aiSuggestions
+        self.aiTranscription = aiTranscription
+        self.aiSpeech = aiSpeech
+        self.termsAccepted = termsAccepted
+        self.privacyPolicyAccepted = privacyPolicyAccepted
+        self.onboardingCompleted = onboardingCompleted
+        self.createdAt = Date()
+        self.updatedAt = Date()
+    }
+}

--- a/apps/swift/Sources/September/Core/Models/Document.swift
+++ b/apps/swift/Sources/September/Core/Models/Document.swift
@@ -1,0 +1,28 @@
+import Foundation
+import SwiftData
+
+// MARK: - Document
+//
+// Plain text document for the Write mode.
+// Mirrors: packages/documents/types/index.ts → DocumentSchema
+
+@Model
+final class Document {
+    @Attribute(.unique) var id: String
+    var name: String?
+    var content: String
+    var createdAt: Date
+    var updatedAt: Date
+
+    init(
+        id: String = UUID().uuidString,
+        name: String? = nil,
+        content: String = ""
+    ) {
+        self.id = id
+        self.name = name
+        self.content = content
+        self.createdAt = Date()
+        self.updatedAt = Date()
+    }
+}

--- a/apps/swift/Sources/September/Core/Models/Panel.swift
+++ b/apps/swift/Sources/September/Core/Models/Panel.swift
@@ -1,0 +1,32 @@
+import Foundation
+import SwiftData
+
+// MARK: - Panel
+//
+// A collection of shortcut buttons linked to a specific app.
+// When that app is focused, this panel auto-appears.
+
+@Model
+final class Panel {
+    @Attribute(.unique) var id: String
+    var name: String
+    var appIdentifier: String?
+    @Relationship(deleteRule: .cascade, inverse: \PanelButton.panel)
+    var buttons: [PanelButton]
+    var createdAt: Date
+    var updatedAt: Date
+
+    init(
+        id: String = UUID().uuidString,
+        name: String,
+        appIdentifier: String? = nil,
+        buttons: [PanelButton] = []
+    ) {
+        self.id = id
+        self.name = name
+        self.appIdentifier = appIdentifier
+        self.buttons = buttons
+        self.createdAt = Date()
+        self.updatedAt = Date()
+    }
+}

--- a/apps/swift/Sources/September/Core/Models/PanelButton.swift
+++ b/apps/swift/Sources/September/Core/Models/PanelButton.swift
@@ -1,0 +1,48 @@
+import Foundation
+import SwiftData
+
+// MARK: - ButtonSize
+
+enum ButtonSize: String, Codable, Sendable {
+    case small
+    case medium
+    case large
+    case extraLarge
+}
+
+// MARK: - PanelButton
+//
+// A single action button within a Panel.
+
+@Model
+final class PanelButton {
+    @Attribute(.unique) var id: String
+    var label: String
+    var icon: String
+    var color: String
+    var actionType: String
+    var prompt: String?
+    var size: ButtonSize
+    var order: Int
+    var panel: Panel?
+
+    init(
+        id: String = UUID().uuidString,
+        label: String,
+        icon: String = "star",
+        color: String = "primary",
+        actionType: String = "aiPrompt",
+        prompt: String? = nil,
+        size: ButtonSize = .medium,
+        order: Int = 0
+    ) {
+        self.id = id
+        self.label = label
+        self.icon = icon
+        self.color = color
+        self.actionType = actionType
+        self.prompt = prompt
+        self.size = size
+        self.order = order
+    }
+}

--- a/apps/swift/Sources/September/Core/Models/Voice.swift
+++ b/apps/swift/Sources/September/Core/Models/Voice.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+// MARK: - Voice
+//
+// Shared domain model used by SpeechService, Settings, and Account.
+// Mirrors: packages/speech/types/index.ts → Voice
+
+struct Voice: Identifiable, Sendable {
+    let id: String
+    let name: String
+    let language: String
+    let gender: String?
+
+    init(id: String, name: String, language: String, gender: String? = nil) {
+        self.id = id
+        self.name = name
+        self.language = language
+        self.gender = gender
+    }
+}

--- a/apps/swift/Sources/September/Features/Keyboard/Views/TypePlaceholderView.swift
+++ b/apps/swift/Sources/September/Features/Keyboard/Views/TypePlaceholderView.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+struct TypePlaceholderView: View {
+    @State private var speechService = AVSpeechService()
+    @State private var testText = "Hello from September"
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Image(systemName: "keyboard")
+                .font(.system(size: 48))
+                .foregroundStyle(DesignColors.primary)
+
+            Text("Type Mode")
+                .font(Typography.heading())
+                .foregroundStyle(DesignColors.foreground)
+
+            Text("Accessible keyboard with AI predictions")
+                .font(Typography.body())
+                .foregroundStyle(DesignColors.mutedForeground)
+
+            Divider()
+
+            VStack(spacing: 12) {
+                Text("TTS Test")
+                    .font(Typography.caption())
+                    .foregroundStyle(DesignColors.mutedForeground)
+
+                TextField("Enter text to speak", text: $testText)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(maxWidth: 300)
+
+                Button {
+                    Task {
+                        try? await speechService.speak(text: testText)
+                    }
+                } label: {
+                    Label(
+                        speechService.isSpeaking ? "Speaking..." : "Speak",
+                        systemImage: speechService.isSpeaking ? "speaker.wave.3" : "speaker"
+                    )
+                }
+                .disabled(speechService.isSpeaking || testText.isEmpty)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(DesignColors.background)
+    }
+}

--- a/apps/swift/Sources/September/Features/Settings/Views/SettingsPlaceholderView.swift
+++ b/apps/swift/Sources/September/Features/Settings/Views/SettingsPlaceholderView.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct SettingsPlaceholderView: View {
+    var body: some View {
+        VStack(spacing: 24) {
+            Image(systemName: "gearshape")
+                .font(.system(size: 48))
+                .foregroundStyle(DesignColors.primary)
+
+            Text("Settings")
+                .font(Typography.heading())
+                .foregroundStyle(DesignColors.foreground)
+
+            Text("Appearance, AI providers, speech, and transcription")
+                .font(Typography.body())
+                .foregroundStyle(DesignColors.mutedForeground)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(DesignColors.background)
+    }
+}

--- a/apps/swift/Sources/September/Features/Talk/Views/TalkPlaceholderView.swift
+++ b/apps/swift/Sources/September/Features/Talk/Views/TalkPlaceholderView.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct TalkPlaceholderView: View {
+    var body: some View {
+        VStack(spacing: 24) {
+            Image(systemName: "waveform")
+                .font(.system(size: 48))
+                .foregroundStyle(DesignColors.primary)
+
+            Text("Talk Mode")
+                .font(Typography.heading())
+                .foregroundStyle(DesignColors.foreground)
+
+            Text("Text-to-speech output and transcription input")
+                .font(Typography.body())
+                .foregroundStyle(DesignColors.mutedForeground)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(DesignColors.background)
+    }
+}

--- a/apps/swift/Sources/September/Features/Writer/Views/WritePlaceholderView.swift
+++ b/apps/swift/Sources/September/Features/Writer/Views/WritePlaceholderView.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct WritePlaceholderView: View {
+    var body: some View {
+        VStack(spacing: 24) {
+            Image(systemName: "doc.text")
+                .font(.system(size: 48))
+                .foregroundStyle(DesignColors.primary)
+
+            Text("Write Mode")
+                .font(Typography.heading())
+                .foregroundStyle(DesignColors.foreground)
+
+            Text("Floating markdown editor with focus modes")
+                .font(Typography.body())
+                .foregroundStyle(DesignColors.mutedForeground)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(DesignColors.background)
+    }
+}

--- a/apps/swift/Sources/September/Services/AI/AIService.swift
+++ b/apps/swift/Sources/September/Services/AI/AIService.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+// MARK: - AIService Protocol
+//
+// Abstraction for AI text generation. Concrete implementations
+// will wrap OpenAI, Anthropic, Ollama, or Foundation Models.
+//
+// generateStructured<T> is intentionally omitted — it will be
+// added in Phase 2 when a real consumer exists, to avoid the
+// existential type (`any AIService`) limitation of generic methods.
+
+protocol AIService: Sendable {
+    func generateText(prompt: String, system: String?, temperature: Double) async throws -> String
+}

--- a/apps/swift/Sources/September/Services/AI/MockAIService.swift
+++ b/apps/swift/Sources/September/Services/AI/MockAIService.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+// MARK: - MockAIService
+//
+// Returns canned responses for development and testing.
+
+actor MockAIService: AIService {
+    func generateText(prompt: String, system: String?, temperature: Double) async throws -> String {
+        // Simulate network latency
+        try await Task.sleep(for: .milliseconds(200))
+        return "Mock AI response for: \(prompt)"
+    }
+}

--- a/apps/swift/Sources/September/Services/Speech/AVSpeechService.swift
+++ b/apps/swift/Sources/September/Services/Speech/AVSpeechService.swift
@@ -1,0 +1,80 @@
+import AVFoundation
+import Foundation
+
+// MARK: - AVSpeechService
+//
+// Concrete SpeechService using AVSpeechSynthesizer.
+// Zero-config TTS baseline — works out of the box with no API key.
+//
+// Must be @MainActor because AVSpeechSynthesizer requires main thread.
+// NSObject inheritance is required for AVSpeechSynthesizerDelegate.
+
+@MainActor
+@Observable
+final class AVSpeechService: NSObject, SpeechService, AVSpeechSynthesizerDelegate {
+    private let synthesizer = AVSpeechSynthesizer()
+    private(set) var isSpeaking = false
+    private var speakContinuation: CheckedContinuation<Void, Never>?
+
+    override init() {
+        super.init()
+        synthesizer.delegate = self
+    }
+
+    func speak(text: String) async throws {
+        guard !text.isEmpty else { return }
+
+        if synthesizer.isSpeaking {
+            synthesizer.stopSpeaking(at: .immediate)
+        }
+
+        let utterance = AVSpeechUtterance(string: text)
+        utterance.voice = AVSpeechSynthesisVoice(language: "en-US")
+        utterance.rate = AVSpeechUtteranceDefaultSpeechRate
+
+        isSpeaking = true
+        await withCheckedContinuation { continuation in
+            speakContinuation = continuation
+            synthesizer.speak(utterance)
+        }
+    }
+
+    func voices() async -> [Voice] {
+        AVSpeechSynthesisVoice.speechVoices().map { voice in
+            Voice(
+                id: voice.identifier,
+                name: voice.name,
+                language: voice.language
+            )
+        }
+    }
+
+    func stop() async {
+        synthesizer.stopSpeaking(at: .immediate)
+        isSpeaking = false
+    }
+
+    // MARK: - AVSpeechSynthesizerDelegate
+
+    nonisolated func speechSynthesizer(
+        _ synthesizer: AVSpeechSynthesizer,
+        didFinish utterance: AVSpeechUtterance
+    ) {
+        Task { @MainActor in
+            isSpeaking = false
+            speakContinuation?.resume()
+            speakContinuation = nil
+        }
+    }
+
+    nonisolated func speechSynthesizer(
+        _ synthesizer: AVSpeechSynthesizer,
+        didCancel utterance: AVSpeechUtterance
+    ) {
+        Task { @MainActor in
+            isSpeaking = false
+            speakContinuation?.resume()
+            speakContinuation = nil
+        }
+    }
+}

--- a/apps/swift/Sources/September/Services/Speech/AVSpeechService.swift
+++ b/apps/swift/Sources/September/Services/Speech/AVSpeechService.swift
@@ -25,6 +25,10 @@ final class AVSpeechService: NSObject, SpeechService, AVSpeechSynthesizerDelegat
         guard !text.isEmpty else { return }
 
         if synthesizer.isSpeaking {
+            // Cancel previous continuation before stopping so the delegate
+            // callback doesn't resume a stale continuation.
+            speakContinuation?.resume()
+            speakContinuation = nil
             synthesizer.stopSpeaking(at: .immediate)
         }
 

--- a/apps/swift/Sources/September/Services/Speech/MockSpeechService.swift
+++ b/apps/swift/Sources/September/Services/Speech/MockSpeechService.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+// MARK: - MockSpeechService
+//
+// Logs to console instead of producing audio. For development and testing.
+
+@MainActor
+@Observable
+final class MockSpeechService: SpeechService {
+    private(set) var isSpeaking = false
+
+    func speak(text: String) async throws {
+        isSpeaking = true
+        print("[MockSpeechService] Speaking: \(text)")
+        try await Task.sleep(for: .milliseconds(500))
+        isSpeaking = false
+    }
+
+    func voices() async -> [Voice] {
+        [
+            Voice(id: "mock-1", name: "Mock Voice", language: "en-US"),
+        ]
+    }
+
+    func stop() async {
+        isSpeaking = false
+        print("[MockSpeechService] Stopped")
+    }
+}

--- a/apps/swift/Sources/September/Services/Speech/SpeechService.swift
+++ b/apps/swift/Sources/September/Services/Speech/SpeechService.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+// MARK: - SpeechService Protocol
+//
+// Abstraction for text-to-speech. Concrete implementations:
+// - AVSpeechService (Phase 0, zero-config baseline)
+// - OpenAI TTS, ElevenLabs (Phase 3+)
+//
+// Must run on MainActor because AVSpeechSynthesizer requires it.
+
+protocol SpeechService: Sendable {
+    func speak(text: String) async throws
+    func voices() async -> [Voice]
+    func stop() async
+}

--- a/apps/swift/Sources/September/Services/Transcription/MockTranscriptionService.swift
+++ b/apps/swift/Sources/September/Services/Transcription/MockTranscriptionService.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+// MARK: - MockTranscriptionService
+//
+// Emits canned text at intervals for development and testing.
+
+actor MockTranscriptionService: TranscriptionService {
+    private var continuation: AsyncStream<String>.Continuation?
+    private var listeningTask: Task<Void, Never>?
+
+    nonisolated let transcriptionStream: AsyncStream<String>
+
+    init() {
+        let (stream, continuation) = AsyncStream<String>.makeStream()
+        self.transcriptionStream = stream
+        self.continuation = continuation
+    }
+
+    func startListening() async throws {
+        listeningTask = Task { [continuation] in
+            let phrases = [
+                "Hello, how are you?",
+                "I'm doing well, thanks.",
+                "What would you like to talk about?",
+            ]
+            for phrase in phrases {
+                guard !Task.isCancelled else { break }
+                try? await Task.sleep(for: .seconds(2))
+                continuation?.yield(phrase)
+            }
+        }
+    }
+
+    func stopListening() async {
+        listeningTask?.cancel()
+        listeningTask = nil
+        continuation?.finish()
+    }
+}

--- a/apps/swift/Sources/September/Services/Transcription/TranscriptionService.swift
+++ b/apps/swift/Sources/September/Services/Transcription/TranscriptionService.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+// MARK: - TranscriptionService Protocol
+//
+// Abstraction for speech-to-text. Concrete implementations:
+// - Apple Speech (Phase 4)
+// - Whisper / Whisper.cpp (Phase 4)
+//
+// Uses AsyncStream for results to work cleanly with strict concurrency.
+
+protocol TranscriptionService: Sendable {
+    func startListening() async throws
+    func stopListening() async
+    var transcriptionStream: AsyncStream<String> { get }
+}

--- a/apps/swift/Tests/SeptemberTests/AVSpeechServiceTests.swift
+++ b/apps/swift/Tests/SeptemberTests/AVSpeechServiceTests.swift
@@ -1,0 +1,46 @@
+import AVFoundation
+import Testing
+
+@testable import September
+
+@Suite("AVSpeechService")
+struct AVSpeechServiceTests {
+
+    @Test("Voices list is non-empty")
+    @MainActor
+    func voicesNonEmpty() async {
+        let service = AVSpeechService()
+        let voices = await service.voices()
+        #expect(!voices.isEmpty)
+    }
+
+    @Test("Voices have required fields")
+    @MainActor
+    func voiceFields() async {
+        let service = AVSpeechService()
+        let voices = await service.voices()
+        guard let first = voices.first else {
+            Issue.record("No voices available")
+            return
+        }
+        #expect(!first.id.isEmpty)
+        #expect(!first.name.isEmpty)
+        #expect(!first.language.isEmpty)
+    }
+
+    @Test("Speak does not throw for valid text")
+    @MainActor
+    func speakDoesNotThrow() async throws {
+        let service = AVSpeechService()
+        // Use a short text so the test completes quickly
+        try await service.speak(text: "Hi")
+    }
+
+    @Test("Speak with empty text is a no-op")
+    @MainActor
+    func speakEmptyText() async throws {
+        let service = AVSpeechService()
+        try await service.speak(text: "")
+        #expect(service.isSpeaking == false)
+    }
+}

--- a/apps/swift/Tests/SeptemberTests/AccountTests.swift
+++ b/apps/swift/Tests/SeptemberTests/AccountTests.swift
@@ -1,0 +1,138 @@
+import Foundation
+import SwiftData
+import Testing
+
+@testable import September
+
+@Suite("Account Model")
+struct AccountTests {
+
+    private func makeContainer() throws -> ModelContainer {
+        let schema = Schema([Account.self, Document.self, Panel.self, PanelButton.self])
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        return try ModelContainer(for: schema, configurations: [config])
+    }
+
+    @Test("Create and fetch account")
+    func createAndFetch() throws {
+        let container = try makeContainer()
+        let context = ModelContext(container)
+
+        let account = Account(name: "Test User", city: "Portland")
+        context.insert(account)
+        try context.save()
+
+        let descriptor = FetchDescriptor<Account>()
+        let accounts = try context.fetch(descriptor)
+
+        #expect(accounts.count == 1)
+        #expect(accounts[0].name == "Test User")
+        #expect(accounts[0].city == "Portland")
+        #expect(accounts[0].onboardingCompleted == false)
+    }
+
+    @Test("Update account fields")
+    func updateFields() throws {
+        let container = try makeContainer()
+        let context = ModelContext(container)
+
+        let account = Account(name: "Original")
+        context.insert(account)
+        try context.save()
+
+        account.name = "Updated"
+        account.primaryDiagnosis = "ALS"
+        account.termsAccepted = true
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<Account>())
+        #expect(fetched[0].name == "Updated")
+        #expect(fetched[0].primaryDiagnosis == "ALS")
+        #expect(fetched[0].termsAccepted == true)
+    }
+
+    @Test("Delete account")
+    func deleteAccount() throws {
+        let container = try makeContainer()
+        let context = ModelContext(container)
+
+        let account = Account(name: "To Delete")
+        context.insert(account)
+        try context.save()
+
+        context.delete(account)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<Account>())
+        #expect(fetched.isEmpty)
+    }
+
+    @Test("AI config defaults roundtrip through SwiftData")
+    func aiConfigDefaults() throws {
+        let container = try makeContainer()
+        let context = ModelContext(container)
+
+        let account = Account(name: "Config Test")
+        context.insert(account)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<Account>())
+        let config = fetched[0].aiSuggestions
+
+        #expect(config.enabled == false)
+        #expect(config.provider == .openai)
+        #expect(config.temperature == 0.7)
+        #expect(config.maxSuggestions == 5)
+    }
+
+    @Test("Modified AI config persists")
+    func modifiedAiConfig() throws {
+        let container = try makeContainer()
+        let context = ModelContext(container)
+
+        let account = Account(name: "Config Modify")
+        account.aiSuggestions.enabled = true
+        account.aiSuggestions.provider = .anthropic
+        account.aiSuggestions.temperature = 0.3
+        account.aiSpeech.provider = .elevenlabs
+        account.aiSpeech.voiceId = "voice-123"
+        context.insert(account)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<Account>())
+        #expect(fetched[0].aiSuggestions.enabled == true)
+        #expect(fetched[0].aiSuggestions.provider == .anthropic)
+        #expect(fetched[0].aiSuggestions.temperature == 0.3)
+        #expect(fetched[0].aiSpeech.provider == .elevenlabs)
+        #expect(fetched[0].aiSpeech.voiceId == "voice-123")
+    }
+
+    @Test("SuggestionsConfig Codable roundtrip with all defaults")
+    func suggestionsConfigCodable() throws {
+        let config = SuggestionsConfig()
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(SuggestionsConfig.self, from: data)
+
+        #expect(decoded.enabled == false)
+        #expect(decoded.provider == .openai)
+        #expect(decoded.temperature == 0.7)
+        #expect(decoded.maxSuggestions == 5)
+        #expect(decoded.contextWindow == 10)
+        #expect(decoded.systemInstructions == nil)
+    }
+
+    @Test("SpeechConfig Codable roundtrip")
+    func speechConfigCodable() throws {
+        var config = SpeechConfig()
+        config.provider = .elevenlabs
+        config.voiceId = "abc"
+        config.speed = 1.5
+
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(SpeechConfig.self, from: data)
+
+        #expect(decoded.provider == .elevenlabs)
+        #expect(decoded.voiceId == "abc")
+        #expect(decoded.speed == 1.5)
+    }
+}

--- a/apps/swift/Tests/SeptemberTests/PanelTests.swift
+++ b/apps/swift/Tests/SeptemberTests/PanelTests.swift
@@ -1,0 +1,87 @@
+import Foundation
+import SwiftData
+import Testing
+
+@testable import September
+
+@Suite("Panel Model")
+struct PanelTests {
+
+    private func makeContainer() throws -> ModelContainer {
+        let schema = Schema([Account.self, Document.self, Panel.self, PanelButton.self])
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        return try ModelContainer(for: schema, configurations: [config])
+    }
+
+    @Test("Create panel with buttons")
+    func createWithButtons() throws {
+        let container = try makeContainer()
+        let context = ModelContext(container)
+
+        let panel = Panel(name: "VS Code", appIdentifier: "com.microsoft.VSCode")
+        let button1 = PanelButton(label: "Save", icon: "square.and.arrow.down", order: 0)
+        let button2 = PanelButton(label: "Build", icon: "hammer", order: 1)
+
+        panel.buttons = [button1, button2]
+        context.insert(panel)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<Panel>())
+        #expect(fetched.count == 1)
+        #expect(fetched[0].name == "VS Code")
+        #expect(fetched[0].buttons.count == 2)
+    }
+
+    @Test("Cascade delete removes buttons")
+    func cascadeDelete() throws {
+        let container = try makeContainer()
+        let context = ModelContext(container)
+
+        let panel = Panel(name: "Test Panel")
+        let button = PanelButton(label: "Action", order: 0)
+        panel.buttons = [button]
+        context.insert(panel)
+        try context.save()
+
+        // Verify button exists
+        let buttonsBefore = try context.fetch(FetchDescriptor<PanelButton>())
+        #expect(buttonsBefore.count == 1)
+
+        // Delete panel
+        context.delete(panel)
+        try context.save()
+
+        // Buttons should be cascaded
+        let panelsAfter = try context.fetch(FetchDescriptor<Panel>())
+        let buttonsAfter = try context.fetch(FetchDescriptor<PanelButton>())
+        #expect(panelsAfter.isEmpty)
+        #expect(buttonsAfter.isEmpty)
+    }
+
+    @Test("PanelButton properties persist")
+    func buttonProperties() throws {
+        let container = try makeContainer()
+        let context = ModelContext(container)
+
+        let panel = Panel(name: "Custom")
+        let button = PanelButton(
+            label: "Generate",
+            icon: "sparkles",
+            color: "primary",
+            actionType: "aiPrompt",
+            prompt: "Summarize the selected text",
+            size: .large,
+            order: 0
+        )
+        panel.buttons = [button]
+        context.insert(panel)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<PanelButton>())
+        #expect(fetched[0].label == "Generate")
+        #expect(fetched[0].icon == "sparkles")
+        #expect(fetched[0].actionType == "aiPrompt")
+        #expect(fetched[0].prompt == "Summarize the selected text")
+        #expect(fetched[0].size == .large)
+    }
+}

--- a/apps/swift/build.sh
+++ b/apps/swift/build.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -euo pipefail
+
+PRODUCT_NAME="September"
+APP_NAME="September.app"
+BUILD_DIR=".build/release"
+APP_DIR="$BUILD_DIR/$APP_NAME"
+
+# Ensure SwiftData macros resolve (requires Xcode toolchain, not CLT)
+export DEVELOPER_DIR="${DEVELOPER_DIR:-/Applications/Xcode.app/Contents/Developer}"
+
+# Dev mode: swift run (uses terminal's accessibility permission)
+if [[ "${1:-}" == "dev" ]]; then
+    echo "Running $PRODUCT_NAME in dev mode..."
+    echo "Tip: Grant your terminal app Accessibility permission to avoid re-granting per build."
+    swift run
+    exit 0
+fi
+
+echo "Building $PRODUCT_NAME..."
+swift build -c release
+
+echo "Creating app bundle..."
+rm -rf "$APP_DIR"
+mkdir -p "$APP_DIR/Contents/MacOS"
+mkdir -p "$APP_DIR/Contents/Resources"
+
+cp "$BUILD_DIR/$PRODUCT_NAME" "$APP_DIR/Contents/MacOS/$PRODUCT_NAME"
+cp Resources/Info.plist "$APP_DIR/Contents/"
+cp Resources/September.entitlements "$APP_DIR/Contents/Resources/"
+
+echo "Signing app bundle..."
+codesign --force --deep --options runtime --timestamp=none \
+    --entitlements Resources/September.entitlements \
+    --sign - "$APP_DIR"
+
+echo ""
+echo "Build complete: $APP_DIR"
+echo "Run with: open \"$APP_DIR\""

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -1,0 +1,30 @@
+# September Web — Claude
+
+Assistive communication app (ALS/MND). Next.js 15, React 19, Tailwind CSS 4, shadcn/ui. Local-first with IndexedDB via TanStack DB.
+
+## Build
+
+Use `pnpm` from workspace root — never `npm` or `yarn`.
+
+| Command                              | Purpose              |
+| ------------------------------------ | -------------------- |
+| `pnpm install`                       | Install dependencies |
+| `pnpm --filter @september/web dev`   | Dev server           |
+| `pnpm --filter @september/web build` | Production build     |
+| `pnpm --filter @september/web lint`  | Lint                 |
+
+## Code Style
+
+- All shared code in `packages/` as `@september/*` workspace packages
+- Forms: `react-hook-form` + `zodResolver`. Use `@september/ui/components/form`
+- Styling: shadcn/ui + Tailwind. Font family is Noto Sans
+- Query hooks return `{ data, isLoading, error }` — error shape: `{ message: string }`
+- Mutation hooks throw errors for error boundaries. Toast for user feedback
+- All hooks must have explicit return type interfaces
+- Prefer editing existing files over creating new ones
+
+## Package Structure
+
+Every `packages/*` module should have: `components/`, `hooks/`, `lib/`, `types/`, `index.ts`, `package.json`, `README.md`.
+
+**READ and UPDATE the README.md in each module directory before and after making changes.**


### PR DESCRIPTION
## Summary

- Scaffolds `apps/swift/` with Swift Package Manager (macOS 14+, strict concurrency)
- Design token system: 20 color tokens (light/dark), typography with JetBrains Mono/Geist fallbacks
- SwiftData models mirroring web app: Account (with Codable AI configs), Document, Panel, PanelButton
- Service protocols + mocks for AI, Speech, Transcription with correct concurrency patterns
- AVSpeechService: concrete TTS using AVSpeechSynthesizer with async/await delegate bridge
- App shell: 4-tab window (Type/Talk/Write/Settings) with placeholder views and design tokens
- FloatingPanel NSPanel infrastructure (non-activating, position persistence) ready for Phase 1
- `build.sh` for signed `.app` bundle creation
- CLAUDE.md restructure: concise root reference, app-specific files for web and Swift
- 14 tests covering Account CRUD, Codable roundtrip, Panel cascade delete, AVSpeech

## Test plan

- [x] `swift build` compiles with no errors (requires `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer`)
- [x] `swift test` — all 14 tests pass (Account CRUD, Panel relationships, AVSpeech voices/speak)
- [x] `./build.sh` produces signed `September.app` bundle
- [x] `swift run September` launches app with 4-tab window
- [x] Toggle System Preferences appearance — color tokens adapt to light/dark
- [x] Click TTS test button in Type tab — AVSpeechService speaks text

Closes #9