### PR TITLE
feat: Phase 3 — Text-to-Speech + Appearance Settings

### DIFF
--- a/apps/swift/README.md
+++ b/apps/swift/README.md
@@ -38,13 +38,18 @@ Sources/September/
 │   │                        # PredictionsPanel, WordSuggestionsBar
 │   ├── Talk/                # Talk mode (placeholder)
 │   ├── Writer/              # Write mode (placeholder)
-│   └── Settings/            # AIProviderSettingsView
+│   └── Settings/
+│       ├── Models/          # AppTheme
+│       └── Views/           # SettingsView, AIProviderSettingsView,
+│                            # TTSSettingsView, AppearanceSettingsView
 └── Services/
     ├── AI/                  # AIService protocol, OpenAI/Anthropic/Ollama actors,
     │                        # HTTPClient, AIProviderRegistry, AIServiceFactory
     ├── KeyInput/            # EventInjector (CGEvent), AccessibilityManager,
     │                        # ModifierState, AXTextService
-    ├── Speech/              # TTS abstraction (AVSpeech, etc.)
+    ├── Speech/              # SpeechService, AVSpeechService, SpeechCoordinator,
+    │                        # TTSAPIService, OpenAITTSService, ElevenLabsTTSService,
+    │                        # AudioPlaybackService
     └── Transcription/       # STT abstraction
 ```
 
@@ -58,6 +63,22 @@ The keyboard provides AI-powered sentence predictions and word suggestions:
 - **AXTextService**: Reads/writes text in the focused app via macOS Accessibility API. Falls back to `EventInjector.typeString()` for apps that don't support AX text mutation.
 - **Settings**: Tap the gearshape in InputBar to open AI provider settings (provider, model, API key, temperature).
 
+### Text-to-Speech (Phase 3)
+
+Three TTS engines with a unified speak button in the input bar:
+
+- **AVSpeech**: Built-in, offline. Voice selection + speed control (0.5x–2.0x).
+- **OpenAI TTS**: Cloud-based HD voices (alloy, echo, fable, onyx, nova, shimmer). Requires API key.
+- **ElevenLabs**: Natural/cloned voices via API. Requires API key.
+- **SpeechCoordinator**: `@MainActor @Observable` that routes between AVSpeech (direct) and API providers (synthesize → `AudioPlaybackService`).
+- **Speak button**: In InputBar, toggles speak/stop with pulsing animation. Speaks current display text using configured engine.
+- **Settings**: Engine cards, voice dropdown, speed slider, preview button.
+
+### Appearance (Phase 3)
+
+- **Theme**: Light / Dark / System — applied via `NSApp.appearance`. `DesignColors` dynamic providers auto-resolve.
+- **Keyboard styles**: 4 variants (Light/Dark × Rainbow/Mono). Derived from theme + style preference via `KeyboardStyle.from(theme:rainbow:)`.
+
 ### Guidelines
 
 - `@Observable` with `@MainActor` for view models (not `ObservableObject`)
@@ -69,7 +90,7 @@ The keyboard provides AI-powered sentence predictions and word suggestions:
 ### Dev Notes
 
 - **Accessibility permission:** The app requires Accessibility permission to inject keystrokes via CGEvent and read/write text via AXUIElement. Grant it in System Settings → Privacy & Security → Accessibility. A banner appears in the keyboard if permission is not granted.
-- **Keyboard styles:** Toggle between Dark Rainbow and Dark Mono via `@AppStorage("keyboardStyle")`. Rainbow applies per-row accent colors; Mono uses uniform neutral.
+- **Keyboard styles:** 4 variants via `@AppStorage("keyboardStyle")` — Dark Rainbow, Dark Mono, Light Rainbow, Light Mono. Rainbow applies per-row accent colors; Mono uses uniform neutral. Theme + style combined via `KeyboardStyle.from(theme:rainbow:)`.
 - **Fonts:** Typography constants reference JetBrains Mono and Geist with system fallbacks. Fonts are not bundled yet.
 - **API keys:** Stored in SwiftData (app sandbox protected). Keychain migration planned for Phase 7. Never log full API keys.
 - **AI providers:** Configured via `AIProviderRegistry`. Add new providers by: (1) adding to `AIProvider` enum, (2) creating an actor conforming to `AIService`, (3) adding registry entry, (4) adding factory case.

--- a/apps/swift/Sources/September/App/SeptemberApp.swift
+++ b/apps/swift/Sources/September/App/SeptemberApp.swift
@@ -26,11 +26,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private let modifierState = ModifierState()
     private let predictionEngine = PredictionEngine()
     private let axTextService = AXTextService()
+    private let speechCoordinator = SpeechCoordinator()
     private var modelContainer: ModelContainer?
     private var positionObservations: [NSObjectProtocol] = []
     private var fittingSizeObservation: NSKeyValueObservation?
 
+    @AppStorage("appTheme") private var appTheme: AppTheme = .system
+
     func applicationDidFinishLaunching(_ notification: Notification) {
+        NSApp.appearance = appTheme.nsAppearance
         accessibility.requestPermission()
 
         do {
@@ -67,6 +71,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             accessibilityManager: accessibility,
             predictionEngine: predictionEngine,
             axTextService: axTextService,
+            speechCoordinator: speechCoordinator,
             onSettingsTapped: { [weak self] in self?.openSettings() }
         )
         .modelContainer(modelContainer!)

--- a/apps/swift/Sources/September/Core/Models/Account.swift
+++ b/apps/swift/Sources/September/Core/Models/Account.swift
@@ -94,4 +94,26 @@ final class Account {
         let suffix = key.suffix(4)
         return "\(prefix)••••\(suffix)"
     }
+
+    // MARK: - SpeechProvider API Key Helpers
+
+    func apiKey(for provider: SpeechProvider) -> String? {
+        let key = apiKeys[provider.rawValue]
+        guard let key, !key.isEmpty else { return nil }
+        return key
+    }
+
+    func setAPIKey(_ key: String, for provider: SpeechProvider) {
+        apiKeys[provider.rawValue] = key
+        updatedAt = Date()
+    }
+
+    func maskedAPIKey(for provider: SpeechProvider) -> String? {
+        guard let key = apiKey(for: provider), key.count > 7 else {
+            return apiKey(for: provider)
+        }
+        let prefix = key.prefix(3)
+        let suffix = key.suffix(4)
+        return "\(prefix)••••\(suffix)"
+    }
 }

--- a/apps/swift/Sources/September/Features/Keyboard/Models/KeyboardStyle.swift
+++ b/apps/swift/Sources/September/Features/Keyboard/Models/KeyboardStyle.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 /// Keyboard visual style — 4 variants: Light/Dark × Rainbow/Mono.
@@ -10,6 +11,25 @@ enum KeyboardStyle: String, CaseIterable, Sendable {
 
     var isRainbow: Bool {
         self == .lightRainbow || self == .darkRainbow
+    }
+
+    /// Derive full keyboard style from theme + rainbow/mono preference.
+    /// For .system theme, uses the current effective appearance.
+    static func from(theme: AppTheme, rainbow: Bool) -> KeyboardStyle {
+        let isDark: Bool
+        switch theme {
+        case .dark:
+            isDark = true
+        case .light:
+            isDark = false
+        case .system:
+            isDark = NSApp.effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+        }
+        if isDark {
+            return rainbow ? .darkRainbow : .darkMono
+        } else {
+            return rainbow ? .lightRainbow : .lightMono
+        }
     }
 
     /// Returns an accent color for the given row index (0-based).

--- a/apps/swift/Sources/September/Features/Keyboard/Views/InputBar.swift
+++ b/apps/swift/Sources/September/Features/Keyboard/Views/InputBar.swift
@@ -11,6 +11,8 @@ func truncateDisplayText(_ text: String, maxLength: Int = 500) -> String {
 /// Display-only — the real input goes to the focused app via CGEvent.
 struct InputBar: View {
     @Binding var displayText: String
+    var isSpeaking: Bool = false
+    var onSpeakTapped: () -> Void = {}
     var onSettingsTapped: () -> Void = {}
 
     var body: some View {
@@ -42,7 +44,43 @@ struct InputBar: View {
             // Mode buttons
             HStack(spacing: 4) {
                 modeButton("keyboard", active: true)
-                modeButton("speaker.wave.2", active: false)
+
+                // Speak / Stop button
+                Button(action: onSpeakTapped) {
+                    Image(systemName: isSpeaking ? "stop.fill" : "speaker.wave.2")
+                        .font(.system(size: 14))
+                        .foregroundStyle(
+                            isSpeaking ? DesignColors.kbAccent : DesignColors.shortcutIcon)
+                        .frame(width: 32, height: 32)
+                        .background(
+                            Circle()
+                                .fill(
+                                    isSpeaking
+                                        ? DesignColors.kbAccent.opacity(0.15) : Color.clear)
+                        )
+                        .overlay(
+                            Circle()
+                                .strokeBorder(
+                                    isSpeaking
+                                        ? DesignColors.kbAccent.opacity(0.5) : Color.clear,
+                                    lineWidth: 1.5
+                                )
+                                .scaleEffect(isSpeaking ? 1.2 : 1.0)
+                                .opacity(isSpeaking ? 0.6 : 0)
+                                .animation(
+                                    isSpeaking
+                                        ? .easeInOut(duration: 0.8).repeatForever(
+                                            autoreverses: true) : .default,
+                                    value: isSpeaking
+                                )
+                        )
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(isSpeaking ? "Stop speaking" : "Speak text")
+                .accessibilityHint(
+                    isSpeaking
+                        ? "Stops current speech" : "Speaks the typed text aloud")
+
                 modeButton("pencil", active: false)
 
                 Button(action: onSettingsTapped) {

--- a/apps/swift/Sources/September/Features/Keyboard/Views/KeyboardAssemblyView.swift
+++ b/apps/swift/Sources/September/Features/Keyboard/Views/KeyboardAssemblyView.swift
@@ -12,6 +12,7 @@ struct KeyboardAssemblyView: View {
     let accessibilityManager: AccessibilityManager
     let predictionEngine: PredictionEngine
     let axTextService: AXTextService
+    let speechCoordinator: SpeechCoordinator
     var onSettingsTapped: () -> Void = {}
 
     @AppStorage("keyboardStyle") private var keyboardStyle: KeyboardStyle = .darkRainbow
@@ -36,6 +37,8 @@ struct KeyboardAssemblyView: View {
                     modifierState: modifierState,
                     accessibilityManager: accessibilityManager,
                     keyboardStyle: keyboardStyle,
+                    isSpeaking: speechCoordinator.isSpeaking,
+                    onSpeakTapped: handleSpeak,
                     onSettingsTapped: onSettingsTapped,
                     displayText: $displayText
                 )
@@ -63,6 +66,22 @@ struct KeyboardAssemblyView: View {
         }
         .onChange(of: account?.aiSuggestions) { _, _ in
             configureEngine()
+        }
+    }
+
+    // MARK: - Speak Action
+
+    private func handleSpeak() {
+        if speechCoordinator.isSpeaking {
+            speechCoordinator.stop()
+        } else {
+            guard !displayText.isEmpty, let account else { return }
+            let config = account.aiSpeech
+            speechCoordinator.speak(
+                text: displayText,
+                config: config,
+                apiKey: account.apiKey(for: config.provider)
+            )
         }
     }
 

--- a/apps/swift/Sources/September/Features/Keyboard/Views/MainKeyboardView.swift
+++ b/apps/swift/Sources/September/Features/Keyboard/Views/MainKeyboardView.swift
@@ -9,13 +9,20 @@ struct MainKeyboardView: View {
     let modifierState: ModifierState
     let accessibilityManager: AccessibilityManager
     let keyboardStyle: KeyboardStyle
+    var isSpeaking: Bool = false
+    var onSpeakTapped: () -> Void = {}
     var onSettingsTapped: () -> Void = {}
     @Binding var displayText: String
 
     var body: some View {
         VStack(spacing: 4) {
-            InputBar(displayText: $displayText, onSettingsTapped: onSettingsTapped)
-                .padding(.bottom, 8)
+            InputBar(
+                displayText: $displayText,
+                isSpeaking: isSpeaking,
+                onSpeakTapped: onSpeakTapped,
+                onSettingsTapped: onSettingsTapped
+            )
+            .padding(.bottom, 8)
 
             ForEach(Array(KeyboardLayout.allRows.enumerated()), id: \.offset) { rowIndex, row in
                 HStack(spacing: 4) {

--- a/apps/swift/Sources/September/Features/Settings/Models/AppTheme.swift
+++ b/apps/swift/Sources/September/Features/Settings/Models/AppTheme.swift
@@ -1,0 +1,37 @@
+import AppKit
+
+// MARK: - AppTheme
+//
+// User-selectable appearance theme. Applied via NSApp.appearance.
+// System mode (nil) inherits from macOS settings and lets
+// DesignColors dynamic providers resolve automatically.
+
+enum AppTheme: String, CaseIterable, Sendable {
+    case light
+    case dark
+    case system
+
+    var nsAppearance: NSAppearance? {
+        switch self {
+        case .light: NSAppearance(named: .aqua)
+        case .dark: NSAppearance(named: .darkAqua)
+        case .system: nil
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .light: "Light"
+        case .dark: "Dark"
+        case .system: "System"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .light: "sun.max"
+        case .dark: "moon"
+        case .system: "circle.lefthalf.filled"
+        }
+    }
+}

--- a/apps/swift/Sources/September/Features/Settings/Views/AppearanceSettingsView.swift
+++ b/apps/swift/Sources/September/Features/Settings/Views/AppearanceSettingsView.swift
@@ -1,0 +1,186 @@
+import SwiftUI
+
+// MARK: - AppearanceSettingsView
+//
+// Appearance settings pane matching design: settings-appearance.png
+//
+// Layout:
+//   Title: "Appearance"
+//   Subtitle: "Customize the look of September."
+//   Divider
+//   Theme cards (Light, Dark, System)
+//   Keyboard Style cards (Rainbow, Mono)
+
+struct AppearanceSettingsView: View {
+    @AppStorage("appTheme") private var appTheme: AppTheme = .system
+    @AppStorage("keyboardStyle") private var keyboardStyle: KeyboardStyle = .darkRainbow
+
+    private var isRainbow: Bool {
+        keyboardStyle.isRainbow
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                // Header
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Appearance")
+                        .font(.system(size: 24, weight: .bold))
+                    Text("Customize the look of September.")
+                        .font(.system(size: 13))
+                        .foregroundStyle(.secondary)
+                }
+
+                Divider()
+
+                // Theme cards
+                VStack(alignment: .leading, spacing: 10) {
+                    Text("Theme")
+                        .font(.system(size: 13, weight: .medium))
+
+                    HStack(spacing: 12) {
+                        themeCard(theme: .light)
+                        themeCard(theme: .dark)
+                        themeCard(theme: .system)
+                    }
+                }
+
+                // Keyboard Style cards
+                VStack(alignment: .leading, spacing: 10) {
+                    Text("Keyboard Style")
+                        .font(.system(size: 13, weight: .medium))
+
+                    HStack(spacing: 12) {
+                        styleCard(rainbow: true)
+                        styleCard(rainbow: false)
+                    }
+                }
+
+                Spacer()
+            }
+            .padding(32)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    // MARK: - Theme Card
+
+    private func themeCard(theme: AppTheme) -> some View {
+        let isSelected = appTheme == theme
+
+        return Button {
+            appTheme = theme
+            NSApp.appearance = theme.nsAppearance
+            keyboardStyle = KeyboardStyle.from(theme: theme, rainbow: isRainbow)
+        } label: {
+            VStack(spacing: 8) {
+                themePreview(theme: theme)
+                    .frame(width: 40, height: 40)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+
+                Text(theme.label)
+                    .font(.system(size: 13, weight: .medium))
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 16)
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .strokeBorder(
+                        isSelected ? Color.blue : Color(nsColor: .separatorColor),
+                        lineWidth: isSelected ? 2 : 1
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("\(theme.label) theme")
+        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+    }
+
+    @ViewBuilder
+    private func themePreview(theme: AppTheme) -> some View {
+        switch theme {
+        case .light:
+            RoundedRectangle(cornerRadius: 6)
+                .fill(.white)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .strokeBorder(Color.gray.opacity(0.3), lineWidth: 1)
+                )
+        case .dark:
+            RoundedRectangle(cornerRadius: 6)
+                .fill(.black)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .strokeBorder(Color.gray.opacity(0.3), lineWidth: 1)
+                )
+        case .system:
+            HStack(spacing: 0) {
+                Color.white
+                Color.black
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+            .overlay(
+                RoundedRectangle(cornerRadius: 6)
+                    .strokeBorder(Color.gray.opacity(0.3), lineWidth: 1)
+            )
+        }
+    }
+
+    // MARK: - Style Card
+
+    private func styleCard(rainbow: Bool) -> some View {
+        let isSelected = isRainbow == rainbow
+
+        return Button {
+            keyboardStyle = KeyboardStyle.from(theme: appTheme, rainbow: rainbow)
+        } label: {
+            VStack(spacing: 8) {
+                miniKeyboardPreview(rainbow: rainbow)
+                    .frame(height: 32)
+
+                Text(rainbow ? "Rainbow" : "Mono")
+                    .font(.system(size: 13, weight: .medium))
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 16)
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .strokeBorder(
+                        isSelected ? Color.blue : Color(nsColor: .separatorColor),
+                        lineWidth: isSelected ? 2 : 1
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("\(rainbow ? "Rainbow" : "Mono") keyboard style")
+        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+    }
+
+    private func miniKeyboardPreview(rainbow: Bool) -> some View {
+        let labels = ["Q", "W", "E", "R"]
+        let colors: [Color] =
+            rainbow
+            ? [.red, .orange, .green, .blue]
+            : [Color(nsColor: .secondaryLabelColor),
+               Color(nsColor: .secondaryLabelColor),
+               Color(nsColor: .secondaryLabelColor),
+               Color(nsColor: .secondaryLabelColor)]
+
+        return HStack(spacing: 3) {
+            ForEach(Array(zip(labels, colors)), id: \.0) { label, color in
+                Text(label)
+                    .font(.system(size: 10, weight: .medium, design: .monospaced))
+                    .foregroundStyle(color)
+                    .frame(width: 20, height: 20)
+                    .background(
+                        RoundedRectangle(cornerRadius: 3)
+                            .fill(Color(nsColor: .controlBackgroundColor))
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 3)
+                            .strokeBorder(Color.gray.opacity(0.2), lineWidth: 0.5)
+                    )
+            }
+        }
+    }
+}

--- a/apps/swift/Sources/September/Features/Settings/Views/SettingsView.swift
+++ b/apps/swift/Sources/September/Features/Settings/Views/SettingsView.swift
@@ -51,11 +51,11 @@ struct SettingsView: View {
             if let account = accounts.first {
                 switch selectedTab {
                 case .appearance:
-                    placeholderPane("Appearance")
+                    AppearanceSettingsView()
                 case .aiProvider:
                     AIProviderSettingsView(account: account)
                 case .textToSpeech:
-                    placeholderPane("Text to Speech")
+                    TTSSettingsView(account: account)
                 case .transcription:
                     placeholderPane("Transcription")
                 }

--- a/apps/swift/Sources/September/Features/Settings/Views/TTSSettingsView.swift
+++ b/apps/swift/Sources/September/Features/Settings/Views/TTSSettingsView.swift
@@ -1,0 +1,248 @@
+import SwiftUI
+
+// MARK: - TTSSettingsView
+//
+// Text-to-Speech settings pane matching design: settings-text-to-speech.png
+//
+// Layout:
+//   Title: "Text to Speech"
+//   Subtitle: "Choose a voice engine and customize playback."
+//   Divider
+//   Engine selection cards (3)
+//   API Key field (conditional)
+//   Voice dropdown
+//   Speed slider (0.5x–2.0x)
+//   Preview Voice button
+
+struct TTSSettingsView: View {
+    @Bindable var account: Account
+    @State private var apiKeyInput = ""
+    @State private var availableVoices: [Voice] = []
+    @State private var isLoadingVoices = false
+    @State private var coordinator = SpeechCoordinator()
+
+    private var config: SpeechConfig {
+        account.aiSpeech
+    }
+
+    private var providerRequiresAPIKey: Bool {
+        config.provider == .openaiTTS || config.provider == .elevenlabs
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                // Header
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Text to Speech")
+                        .font(.system(size: 24, weight: .bold))
+                    Text("Choose a voice engine and customize playback.")
+                        .font(.system(size: 13))
+                        .foregroundStyle(.secondary)
+                }
+
+                Divider()
+
+                // Engine cards
+                VStack(alignment: .leading, spacing: 10) {
+                    Text("Engine")
+                        .font(.system(size: 13, weight: .medium))
+
+                    HStack(spacing: 12) {
+                        engineCard(
+                            provider: .avSpeech,
+                            icon: "waveform",
+                            name: "Apple AVSpeech",
+                            subtitle: "Built-in, offline"
+                        )
+                        engineCard(
+                            provider: .openaiTTS,
+                            icon: "sparkles",
+                            name: "OpenAI TTS",
+                            subtitle: "HD voices, cloud"
+                        )
+                        engineCard(
+                            provider: .elevenlabs,
+                            icon: "person.wave.2",
+                            name: "ElevenLabs",
+                            subtitle: "Natural voices"
+                        )
+                    }
+                }
+
+                // API Key (only for providers that need it)
+                if providerRequiresAPIKey {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("API Key")
+                            .font(.system(size: 13, weight: .medium))
+
+                        SecureField(
+                            account.maskedAPIKey(for: config.provider) ?? "Enter API key",
+                            text: $apiKeyInput
+                        )
+                        .textFieldStyle(.roundedBorder)
+                        .font(.system(size: 13, design: .monospaced))
+                        .onSubmit { saveAPIKey() }
+                        .onChange(of: apiKeyInput) { _, _ in saveAPIKey() }
+                    }
+                }
+
+                // Voice dropdown
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Voice")
+                        .font(.system(size: 13, weight: .medium))
+
+                    Picker("Voice", selection: voiceBinding) {
+                        Text("Default").tag(String?.none)
+                        ForEach(availableVoices) { voice in
+                            Text("\(voice.name) (\(voice.language))").tag(Optional(voice.id))
+                        }
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.menu)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8)
+                            .strokeBorder(Color(nsColor: .separatorColor), lineWidth: 1)
+                    )
+                }
+
+                // Speed slider
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack {
+                        Text("Speed")
+                            .font(.system(size: 13, weight: .medium))
+                        Spacer()
+                        Text(String(format: "%.1fx", config.speed))
+                            .font(.system(size: 13, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Slider(
+                        value: $account.aiSpeech.speed,
+                        in: 0.5...2.0,
+                        step: 0.1
+                    )
+                    .tint(.blue)
+                }
+
+                // Preview Voice button
+                VStack(alignment: .leading, spacing: 6) {
+                    Button {
+                        previewVoice()
+                    } label: {
+                        HStack {
+                            Image(systemName: coordinator.isSpeaking ? "stop.fill" : "play.fill")
+                            Text(coordinator.isSpeaking ? "Stop Preview" : "Preview Voice")
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 10)
+                        .background(
+                            RoundedRectangle(cornerRadius: 8)
+                                .fill(Color.blue)
+                        )
+                        .foregroundStyle(.white)
+                        .font(.system(size: 13, weight: .medium))
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(
+                        coordinator.isSpeaking ? "Stop preview" : "Preview voice")
+
+                    Text("Plays a short sample with current settings")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.tertiary)
+                }
+
+                Spacer()
+            }
+            .padding(32)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .onAppear {
+            apiKeyInput = account.apiKey(for: config.provider) ?? ""
+            loadVoices()
+        }
+        .onChange(of: config.provider) { _, _ in
+            apiKeyInput = account.apiKey(for: config.provider) ?? ""
+            account.aiSpeech.voiceId = nil
+            account.aiSpeech.voiceName = nil
+            loadVoices()
+        }
+    }
+
+    // MARK: - Engine Card
+
+    private func engineCard(
+        provider: SpeechProvider, icon: String, name: String, subtitle: String
+    ) -> some View {
+        let isSelected = config.provider == provider
+
+        return Button {
+            account.aiSpeech.provider = provider
+        } label: {
+            VStack(spacing: 8) {
+                Image(systemName: icon)
+                    .font(.system(size: 24))
+                    .foregroundStyle(isSelected ? .blue : .secondary)
+                Text(name)
+                    .font(.system(size: 13, weight: .medium))
+                Text(subtitle)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 16)
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .strokeBorder(
+                        isSelected ? Color.blue : Color(nsColor: .separatorColor),
+                        lineWidth: isSelected ? 2 : 1
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("\(name) engine")
+        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+    }
+
+    // MARK: - Helpers
+
+    private var voiceBinding: Binding<String?> {
+        Binding(
+            get: { config.voiceId },
+            set: { newValue in
+                account.aiSpeech.voiceId = newValue
+                account.aiSpeech.voiceName = availableVoices.first { $0.id == newValue }?.name
+            }
+        )
+    }
+
+    private func saveAPIKey() {
+        guard !apiKeyInput.isEmpty else { return }
+        account.setAPIKey(apiKeyInput, for: config.provider)
+    }
+
+    private func loadVoices() {
+        isLoadingVoices = true
+        Task {
+            let apiKey = account.apiKey(for: config.provider)
+            availableVoices = await coordinator.voices(for: config.provider, apiKey: apiKey)
+            isLoadingVoices = false
+        }
+    }
+
+    private func previewVoice() {
+        if coordinator.isSpeaking {
+            coordinator.stop()
+        } else {
+            let apiKey = account.apiKey(for: config.provider)
+            coordinator.speak(
+                text: "Hello, I'm your voice assistant.",
+                config: config,
+                apiKey: apiKey
+            )
+        }
+    }
+}

--- a/apps/swift/Sources/September/Services/Speech/AVSpeechService.swift
+++ b/apps/swift/Sources/September/Services/Speech/AVSpeechService.swift
@@ -21,20 +21,27 @@ final class AVSpeechService: NSObject, SpeechService, AVSpeechSynthesizerDelegat
         synthesizer.delegate = self
     }
 
-    func speak(text: String) async throws {
+    func speak(text: String, voiceId: String?, speed: Double) async throws {
         guard !text.isEmpty else { return }
 
         if synthesizer.isSpeaking {
-            // Cancel previous continuation before stopping so the delegate
-            // callback doesn't resume a stale continuation.
             speakContinuation?.resume()
             speakContinuation = nil
             synthesizer.stopSpeaking(at: .immediate)
         }
 
         let utterance = AVSpeechUtterance(string: text)
-        utterance.voice = AVSpeechSynthesisVoice(language: "en-US")
-        utterance.rate = AVSpeechUtteranceDefaultSpeechRate
+
+        if let voiceId, let voice = AVSpeechSynthesisVoice(identifier: voiceId) {
+            utterance.voice = voice
+        } else {
+            utterance.voice = AVSpeechSynthesisVoice(language: "en-US")
+        }
+
+        // Map user speed (0.5–2.0) to AVSpeech rate.
+        // AVSpeechUtteranceDefaultSpeechRate is ~0.5 on the 0.0–1.0 scale.
+        let clampedSpeed = min(max(speed, 0.5), 2.0)
+        utterance.rate = Float(clampedSpeed) * AVSpeechUtteranceDefaultSpeechRate
 
         isSpeaking = true
         await withCheckedContinuation { continuation in

--- a/apps/swift/Sources/September/Services/Speech/AudioPlaybackService.swift
+++ b/apps/swift/Sources/September/Services/Speech/AudioPlaybackService.swift
@@ -1,0 +1,63 @@
+import AVFoundation
+import Foundation
+
+// MARK: - AudioPlaybackService
+//
+// Plays audio data (MP3/AAC) returned by cloud TTS providers.
+// Wraps AVAudioPlayer with observable isSpeaking state for UI binding.
+
+@MainActor
+@Observable
+final class AudioPlaybackService: NSObject, AVAudioPlayerDelegate {
+    private(set) var isSpeaking = false
+    private var player: AVAudioPlayer?
+    private var playbackContinuation: CheckedContinuation<Void, Never>?
+
+    func play(data: Data) async throws {
+        stop()
+
+        let audioPlayer = try AVAudioPlayer(data: data)
+        audioPlayer.delegate = self
+        player = audioPlayer
+
+        isSpeaking = true
+        await withCheckedContinuation { continuation in
+            playbackContinuation = continuation
+            audioPlayer.play()
+        }
+    }
+
+    func stop() {
+        player?.stop()
+        player = nil
+        isSpeaking = false
+        playbackContinuation?.resume()
+        playbackContinuation = nil
+    }
+
+    // MARK: - AVAudioPlayerDelegate
+
+    nonisolated func audioPlayerDidFinishPlaying(
+        _ player: AVAudioPlayer,
+        successfully flag: Bool
+    ) {
+        Task { @MainActor in
+            isSpeaking = false
+            self.player = nil
+            playbackContinuation?.resume()
+            playbackContinuation = nil
+        }
+    }
+
+    nonisolated func audioPlayerDecodeErrorDidOccur(
+        _ player: AVAudioPlayer,
+        error: (any Error)?
+    ) {
+        Task { @MainActor in
+            isSpeaking = false
+            self.player = nil
+            playbackContinuation?.resume()
+            playbackContinuation = nil
+        }
+    }
+}

--- a/apps/swift/Sources/September/Services/Speech/ElevenLabsTTSService.swift
+++ b/apps/swift/Sources/September/Services/Speech/ElevenLabsTTSService.swift
@@ -1,0 +1,74 @@
+import Foundation
+import os
+
+// MARK: - ElevenLabs TTS Service
+//
+// URLSession-based client for ElevenLabs Text-to-Speech API.
+// Supports cloned voices. Returns MP3 audio data.
+//
+// API: POST https://api.elevenlabs.io/v1/text-to-speech/{voice_id}
+// Voices: GET https://api.elevenlabs.io/v1/voices
+
+actor ElevenLabsTTSService: TTSAPIService {
+    private let apiKey: String
+    private let session: URLSession
+    private let httpClient = HTTPClient()
+    private static let logger = Logger(
+        subsystem: "to.september.app", category: "ElevenLabsTTS")
+
+    private static let defaultVoiceId = "21m00Tcm4TlvDq8ikWAM"  // Rachel
+
+    init(apiKey: String, session: URLSession = .shared) {
+        self.apiKey = apiKey
+        self.session = session
+    }
+
+    func synthesize(text: String, voiceId: String?, speed: Double) async throws -> Data {
+        let voice = voiceId ?? Self.defaultVoiceId
+
+        let body: [String: Any] = [
+            "text": text,
+            "model_id": "eleven_monolingual_v1",
+        ]
+
+        guard let encodedVoice = voice.addingPercentEncoding(
+            withAllowedCharacters: .urlPathAllowed),
+            let url = URL(
+                string: "https://api.elevenlabs.io/v1/text-to-speech/\(encodedVoice)")
+        else {
+            throw AIServiceError.invalidResponse
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue(apiKey, forHTTPHeaderField: "xi-api-key")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("audio/mpeg", forHTTPHeaderField: "Accept")
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        return try await httpClient.execute(request: request, session: session)
+    }
+
+    func voices() async throws -> [Voice] {
+        var request = URLRequest(
+            url: URL(string: "https://api.elevenlabs.io/v1/voices")!)
+        request.httpMethod = "GET"
+        request.setValue(apiKey, forHTTPHeaderField: "xi-api-key")
+
+        let data = try await httpClient.execute(request: request, session: session)
+
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let voicesArray = json["voices"] as? [[String: Any]]
+        else {
+            Self.logger.error("Failed to parse ElevenLabs voices response")
+            throw AIServiceError.invalidResponse
+        }
+
+        return voicesArray.compactMap { dict -> Voice? in
+            guard let id = dict["voice_id"] as? String,
+                let name = dict["name"] as? String
+            else { return nil }
+            return Voice(id: id, name: name, language: "en")
+        }
+    }
+}

--- a/apps/swift/Sources/September/Services/Speech/MockSpeechService.swift
+++ b/apps/swift/Sources/September/Services/Speech/MockSpeechService.swift
@@ -8,10 +8,14 @@ import Foundation
 @Observable
 final class MockSpeechService: SpeechService {
     private(set) var isSpeaking = false
+    private(set) var lastVoiceId: String?
+    private(set) var lastSpeed: Double?
 
-    func speak(text: String) async throws {
+    func speak(text: String, voiceId: String?, speed: Double) async throws {
         isSpeaking = true
-        print("[MockSpeechService] Speaking: \(text)")
+        lastVoiceId = voiceId
+        lastSpeed = speed
+        print("[MockSpeechService] Speaking: \(text) voice=\(voiceId ?? "nil") speed=\(speed)")
         try await Task.sleep(for: .milliseconds(500))
         isSpeaking = false
     }

--- a/apps/swift/Sources/September/Services/Speech/OpenAITTSService.swift
+++ b/apps/swift/Sources/September/Services/Speech/OpenAITTSService.swift
@@ -1,0 +1,55 @@
+import Foundation
+import os
+
+// MARK: - OpenAI TTS Service
+//
+// URLSession-based client for OpenAI's Text-to-Speech API.
+// Returns MP3 audio data for playback via AudioPlaybackService.
+//
+// API: POST https://api.openai.com/v1/audio/speech
+// Voices: alloy, echo, fable, onyx, nova, shimmer
+
+actor OpenAITTSService: TTSAPIService {
+    private let apiKey: String
+    private let session: URLSession
+    private let httpClient = HTTPClient()
+    private static let logger = Logger(subsystem: "to.september.app", category: "OpenAITTS")
+
+    static let availableVoices: [Voice] = [
+        Voice(id: "alloy", name: "Alloy", language: "en"),
+        Voice(id: "echo", name: "Echo", language: "en"),
+        Voice(id: "fable", name: "Fable", language: "en"),
+        Voice(id: "onyx", name: "Onyx", language: "en"),
+        Voice(id: "nova", name: "Nova", language: "en"),
+        Voice(id: "shimmer", name: "Shimmer", language: "en"),
+    ]
+
+    init(apiKey: String, session: URLSession = .shared) {
+        self.apiKey = apiKey
+        self.session = session
+    }
+
+    func synthesize(text: String, voiceId: String?, speed: Double) async throws -> Data {
+        let voice = voiceId ?? "alloy"
+        let clampedSpeed = min(max(speed, 0.25), 4.0)
+
+        let body: [String: Any] = [
+            "model": "tts-1",
+            "input": text,
+            "voice": voice,
+            "speed": clampedSpeed,
+        ]
+
+        var request = URLRequest(url: URL(string: "https://api.openai.com/v1/audio/speech")!)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        return try await httpClient.execute(request: request, session: session)
+    }
+
+    func voices() async throws -> [Voice] {
+        Self.availableVoices
+    }
+}

--- a/apps/swift/Sources/September/Services/Speech/SpeechCoordinator.swift
+++ b/apps/swift/Sources/September/Services/Speech/SpeechCoordinator.swift
@@ -1,0 +1,91 @@
+import Foundation
+import os
+
+// MARK: - SpeechCoordinator
+//
+// Unified TTS interface that routes between AVSpeech (direct synthesis)
+// and API-based providers (OpenAI TTS, ElevenLabs → AudioPlaybackService).
+//
+// Owns the AVSpeechService and AudioPlaybackService instances.
+// UI binds to isSpeaking for visual feedback.
+
+@MainActor
+@Observable
+final class SpeechCoordinator {
+    private(set) var isSpeaking = false
+    private let avSpeechService = AVSpeechService()
+    private let audioPlayback = AudioPlaybackService()
+    private var currentTask: Task<Void, Never>?
+    private static let logger = Logger(
+        subsystem: "to.september.app", category: "SpeechCoordinator")
+
+    func speak(text: String, config: SpeechConfig, apiKey: String?) {
+        stop()
+
+        currentTask = Task {
+            isSpeaking = true
+            defer {
+                isSpeaking = false
+                currentTask = nil
+            }
+
+            do {
+                switch config.provider {
+                case .avSpeech:
+                    try await avSpeechService.speak(
+                        text: text, voiceId: config.voiceId, speed: config.speed)
+
+                case .openaiTTS:
+                    guard let apiKey, !apiKey.isEmpty else {
+                        Self.logger.warning("OpenAI TTS requires API key")
+                        return
+                    }
+                    let service = OpenAITTSService(apiKey: apiKey)
+                    let data = try await service.synthesize(
+                        text: text, voiceId: config.voiceId, speed: config.speed)
+                    guard !Task.isCancelled else { return }
+                    try await audioPlayback.play(data: data)
+
+                case .elevenlabs:
+                    guard let apiKey, !apiKey.isEmpty else {
+                        Self.logger.warning("ElevenLabs requires API key")
+                        return
+                    }
+                    let service = ElevenLabsTTSService(apiKey: apiKey)
+                    let data = try await service.synthesize(
+                        text: text, voiceId: config.voiceId, speed: config.speed)
+                    guard !Task.isCancelled else { return }
+                    try await audioPlayback.play(data: data)
+                }
+            } catch {
+                Self.logger.error("Speech failed: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    func stop() {
+        currentTask?.cancel()
+        currentTask = nil
+
+        Task { @MainActor in
+            await avSpeechService.stop()
+        }
+        audioPlayback.stop()
+        isSpeaking = false
+    }
+
+    func voices(for provider: SpeechProvider, apiKey: String?) async -> [Voice] {
+        switch provider {
+        case .avSpeech:
+            return await avSpeechService.voices()
+
+        case .openaiTTS:
+            return OpenAITTSService.availableVoices
+
+        case .elevenlabs:
+            guard let apiKey, !apiKey.isEmpty else { return [] }
+            let service = ElevenLabsTTSService(apiKey: apiKey)
+            return (try? await service.voices()) ?? []
+        }
+    }
+}

--- a/apps/swift/Sources/September/Services/Speech/SpeechService.swift
+++ b/apps/swift/Sources/September/Services/Speech/SpeechService.swift
@@ -4,12 +4,18 @@ import Foundation
 //
 // Abstraction for text-to-speech. Concrete implementations:
 // - AVSpeechService (Phase 0, zero-config baseline)
-// - OpenAI TTS, ElevenLabs (Phase 3+)
+// - OpenAI TTS, ElevenLabs via TTSAPIService (Phase 3+)
 //
 // Must run on MainActor because AVSpeechSynthesizer requires it.
 
 protocol SpeechService: Sendable {
-    func speak(text: String) async throws
+    func speak(text: String, voiceId: String?, speed: Double) async throws
     func voices() async -> [Voice]
     func stop() async
+}
+
+extension SpeechService {
+    func speak(text: String) async throws {
+        try await speak(text: text, voiceId: nil, speed: 1.0)
+    }
 }

--- a/apps/swift/Sources/September/Services/Speech/TTSAPIService.swift
+++ b/apps/swift/Sources/September/Services/Speech/TTSAPIService.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+// MARK: - TTSAPIService Protocol
+//
+// Abstraction for cloud-based TTS providers that return audio data.
+// Unlike SpeechService (which plays audio directly), TTSAPIService
+// returns raw audio bytes for playback via AudioPlaybackService.
+//
+// Implementations: OpenAITTSService, ElevenLabsTTSService
+
+protocol TTSAPIService: Sendable {
+    func synthesize(text: String, voiceId: String?, speed: Double) async throws -> Data
+    func voices() async throws -> [Voice]
+}

--- a/apps/swift/Tests/SeptemberTests/AVSpeechServiceTests.swift
+++ b/apps/swift/Tests/SeptemberTests/AVSpeechServiceTests.swift
@@ -43,4 +43,30 @@ struct AVSpeechServiceTests {
         try await service.speak(text: "")
         #expect(service.isSpeaking == false)
     }
+
+    @Test("Speak with voice and speed does not throw")
+    @MainActor
+    func speakWithVoiceAndSpeed() async throws {
+        let service = AVSpeechService()
+        let voices = await service.voices()
+        guard let voice = voices.first else {
+            Issue.record("No voices available")
+            return
+        }
+        try await service.speak(text: "Hi", voiceId: voice.id, speed: 1.5)
+    }
+
+    @Test("Speak with invalid voice falls back to default")
+    @MainActor
+    func speakWithInvalidVoice() async throws {
+        let service = AVSpeechService()
+        try await service.speak(text: "Hi", voiceId: "nonexistent-voice-id", speed: 1.0)
+    }
+
+    @Test("Default speak calls through protocol extension")
+    @MainActor
+    func defaultSpeakExtension() async throws {
+        let service = AVSpeechService()
+        try await service.speak(text: "Hi")
+    }
 }

--- a/apps/swift/Tests/SeptemberTests/AccountTests.swift
+++ b/apps/swift/Tests/SeptemberTests/AccountTests.swift
@@ -177,6 +177,49 @@ struct AccountTests {
         #expect(account.updatedAt >= before)
     }
 
+    // MARK: - SpeechProvider API Keys
+
+    @Test("SpeechProvider API key roundtrip through SwiftData")
+    func speechProviderApiKeyRoundtrip() throws {
+        let container = try makeContainer()
+        let context = ModelContext(container)
+
+        let account = Account(name: "Speech Key Test")
+        account.setAPIKey("sk-openai-tts-key", for: .openaiTTS)
+        account.setAPIKey("el-elevenlabs-key", for: .elevenlabs)
+        context.insert(account)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<Account>())
+        #expect(fetched[0].apiKey(for: .openaiTTS) == "sk-openai-tts-key")
+        #expect(fetched[0].apiKey(for: .elevenlabs) == "el-elevenlabs-key")
+        #expect(fetched[0].apiKey(for: .avSpeech) == nil)
+    }
+
+    @Test("SpeechProvider keys do not collide with AIProvider keys")
+    func speechProviderNoCollision() {
+        let account = Account(name: "Collision Test")
+        account.setAPIKey("ai-openai-key", for: .openai)
+        account.setAPIKey("tts-openai-key", for: .openaiTTS)
+
+        #expect(account.apiKey(for: .openai) == "ai-openai-key")
+        #expect(account.apiKey(for: .openaiTTS) == "tts-openai-key")
+    }
+
+    @Test("SpeechProvider masked API key")
+    func speechProviderMaskedKey() {
+        let account = Account(name: "Speech Mask")
+        account.setAPIKey("el-1234567890abcdef", for: .elevenlabs)
+        #expect(account.maskedAPIKey(for: .elevenlabs) == "el-••••cdef")
+    }
+
+    @Test("SpeechProvider API key returns nil for empty string")
+    func speechProviderEmptyKey() {
+        let account = Account(name: "Empty Speech Key")
+        account.apiKeys["openaiTTS"] = ""
+        #expect(account.apiKey(for: .openaiTTS) == nil)
+    }
+
     // MARK: - Codable Roundtrips
 
     @Test("SpeechConfig Codable roundtrip")

--- a/apps/swift/Tests/SeptemberTests/AppThemeTests.swift
+++ b/apps/swift/Tests/SeptemberTests/AppThemeTests.swift
@@ -1,0 +1,49 @@
+import AppKit
+import Testing
+
+@testable import September
+
+@Suite("AppTheme")
+struct AppThemeTests {
+
+    @Test("All cases exist")
+    func allCases() {
+        #expect(AppTheme.allCases.count == 3)
+        #expect(AppTheme.allCases.contains(.light))
+        #expect(AppTheme.allCases.contains(.dark))
+        #expect(AppTheme.allCases.contains(.system))
+    }
+
+    @Test("Light theme returns aqua appearance")
+    func lightAppearance() {
+        let appearance = AppTheme.light.nsAppearance
+        #expect(appearance != nil)
+        #expect(appearance?.name == .aqua)
+    }
+
+    @Test("Dark theme returns darkAqua appearance")
+    func darkAppearance() {
+        let appearance = AppTheme.dark.nsAppearance
+        #expect(appearance != nil)
+        #expect(appearance?.name == .darkAqua)
+    }
+
+    @Test("System theme returns nil appearance")
+    func systemAppearance() {
+        #expect(AppTheme.system.nsAppearance == nil)
+    }
+
+    @Test("Labels are human-readable")
+    func labels() {
+        #expect(AppTheme.light.label == "Light")
+        #expect(AppTheme.dark.label == "Dark")
+        #expect(AppTheme.system.label == "System")
+    }
+
+    @Test("Icons are SF Symbol names")
+    func icons() {
+        #expect(AppTheme.light.icon == "sun.max")
+        #expect(AppTheme.dark.icon == "moon")
+        #expect(AppTheme.system.icon == "circle.lefthalf.filled")
+    }
+}

--- a/apps/swift/Tests/SeptemberTests/ElevenLabsTTSServiceTests.swift
+++ b/apps/swift/Tests/SeptemberTests/ElevenLabsTTSServiceTests.swift
@@ -1,0 +1,13 @@
+import Foundation
+import Testing
+
+@testable import September
+
+@Suite("ElevenLabsTTSService")
+struct ElevenLabsTTSServiceTests {
+
+    @Test("Service initializes with API key")
+    func initWithApiKey() {
+        let _ = ElevenLabsTTSService(apiKey: "test-key")
+    }
+}

--- a/apps/swift/Tests/SeptemberTests/KeyboardStyleTests.swift
+++ b/apps/swift/Tests/SeptemberTests/KeyboardStyleTests.swift
@@ -65,4 +65,26 @@ struct KeyboardStyleTests {
     func allCases() {
         #expect(KeyboardStyle.allCases.count == 4)
     }
+
+    // MARK: - from(theme:rainbow:)
+
+    @Test("Dark theme + rainbow → darkRainbow")
+    func fromDarkRainbow() {
+        #expect(KeyboardStyle.from(theme: .dark, rainbow: true) == .darkRainbow)
+    }
+
+    @Test("Dark theme + mono → darkMono")
+    func fromDarkMono() {
+        #expect(KeyboardStyle.from(theme: .dark, rainbow: false) == .darkMono)
+    }
+
+    @Test("Light theme + rainbow → lightRainbow")
+    func fromLightRainbow() {
+        #expect(KeyboardStyle.from(theme: .light, rainbow: true) == .lightRainbow)
+    }
+
+    @Test("Light theme + mono → lightMono")
+    func fromLightMono() {
+        #expect(KeyboardStyle.from(theme: .light, rainbow: false) == .lightMono)
+    }
 }

--- a/apps/swift/Tests/SeptemberTests/OpenAITTSServiceTests.swift
+++ b/apps/swift/Tests/SeptemberTests/OpenAITTSServiceTests.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Testing
+
+@testable import September
+
+@Suite("OpenAITTSService")
+struct OpenAITTSServiceTests {
+
+    @Test("Static voices list contains expected voices")
+    func staticVoices() async throws {
+        let service = OpenAITTSService(apiKey: "test-key")
+        let voices = try await service.voices()
+
+        #expect(voices.count == 6)
+
+        let ids = voices.map(\.id)
+        #expect(ids.contains("alloy"))
+        #expect(ids.contains("echo"))
+        #expect(ids.contains("nova"))
+        #expect(ids.contains("shimmer"))
+    }
+
+    @Test("Voices have name and language")
+    func voiceFields() async throws {
+        let service = OpenAITTSService(apiKey: "test-key")
+        let voices = try await service.voices()
+
+        for voice in voices {
+            #expect(!voice.id.isEmpty)
+            #expect(!voice.name.isEmpty)
+            #expect(!voice.language.isEmpty)
+        }
+    }
+}

--- a/apps/swift/Tests/SeptemberTests/SpeechCoordinatorTests.swift
+++ b/apps/swift/Tests/SeptemberTests/SpeechCoordinatorTests.swift
@@ -1,0 +1,62 @@
+import Foundation
+import Testing
+
+@testable import September
+
+@Suite("SpeechCoordinator")
+struct SpeechCoordinatorTests {
+
+    @Test("Initial state is not speaking")
+    @MainActor
+    func initialState() {
+        let coordinator = SpeechCoordinator()
+        #expect(coordinator.isSpeaking == false)
+    }
+
+    @Test("Stop when not speaking is a no-op")
+    @MainActor
+    func stopWhenNotSpeaking() {
+        let coordinator = SpeechCoordinator()
+        coordinator.stop()
+        #expect(coordinator.isSpeaking == false)
+    }
+
+    @Test("AVSpeech voices are available")
+    @MainActor
+    func avSpeechVoices() async {
+        let coordinator = SpeechCoordinator()
+        let voices = await coordinator.voices(for: .avSpeech, apiKey: nil)
+        #expect(!voices.isEmpty)
+    }
+
+    @Test("OpenAI TTS voices are static list")
+    @MainActor
+    func openaiVoices() async {
+        let coordinator = SpeechCoordinator()
+        let voices = await coordinator.voices(for: .openaiTTS, apiKey: "test")
+        #expect(voices.count == 6)
+    }
+
+    @Test("ElevenLabs voices returns empty without API key")
+    @MainActor
+    func elevenlabsVoicesNoKey() async {
+        let coordinator = SpeechCoordinator()
+        let voices = await coordinator.voices(for: .elevenlabs, apiKey: nil)
+        #expect(voices.isEmpty)
+    }
+
+    @Test("Speak with AVSpeech sets isSpeaking")
+    @MainActor
+    func speakAVSpeech() async throws {
+        let coordinator = SpeechCoordinator()
+        let config = SpeechConfig(provider: .avSpeech)
+        coordinator.speak(text: "Hi", config: config, apiKey: nil)
+
+        // Give the task a moment to start
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(coordinator.isSpeaking == true)
+
+        coordinator.stop()
+        #expect(coordinator.isSpeaking == false)
+    }
+}


### PR DESCRIPTION
## Summary

Closes #12

- **TTS Providers**: AVSpeech (polished with voice selection + speed 0.5x–2.0x), OpenAI TTS (6 HD voices), ElevenLabs (dynamic/cloned voices)
- **Audio Playback**: AVAudioPlayer wrapper for cloud TTS providers returning MP3 data
- **SpeechCoordinator**: Unified routing between AVSpeech (direct) and API providers (synthesize → playback)
- **Speak Button**: InputBar speaker button toggles speak/stop with pulsing animation, speaks current display text
- **TTS Settings**: Engine selection cards, voice dropdown, speed slider, preview button
- **Appearance Settings**: Theme cards (Light/Dark/System via NSApp.appearance), keyboard style cards (Rainbow/Mono)
- **Light Theme Keyboard**: All 4 variants work (Dark Rainbow, Dark Mono, Light Rainbow, Light Mono) via DesignColors dynamic providers
- **Account**: SpeechProvider API key helpers (no collision with AIProvider keys)

## Pre-Landing Review

2 informational issues found and fixed:
- ElevenLabs voice ID now percent-encoded before URL interpolation
- SpeechCoordinator.stop() Task wrapper reviewed (acceptable for @MainActor context)

## Test plan
- [x] All Swift tests pass (113 tests, 16 suites, 0 failures)
- [x] Build passes (`swift build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)