### PR TITLE
feat: port mobile nav to chat page

### DIFF
--- a/apps/web/app/(app)/chats/[id]/page.tsx
+++ b/apps/web/app/(app)/chats/[id]/page.tsx
@@ -6,6 +6,7 @@ import { use } from 'react';
 import { ArrowPathIcon, ExclamationTriangleIcon, TvIcon } from '@heroicons/react/24/outline';
 import { toast } from 'sonner';
 
+import MobileNav from '@/components/nav/mobile';
 import SidebarLayout from '@/components/sidebar/layout';
 import { Button } from '@september/ui/components/button';
 import { Separator } from '@september/ui/components/separator';
@@ -210,19 +211,29 @@ export default function ChatPage({ params }: ChatPageProps) {
   return (
     <>
       <SidebarLayout.Header>
-        <SidebarTrigger className="-ml-1" />
-        <Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
-        {chat && <EditableChatTitle chatId={chat.id} title={chat.title} />}
-        <div className="ml-auto flex items-center gap-2">
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={handleOpenDisplay}
-            className="flex items-center gap-2"
-          >
+        {/* Mobile: branded top bar with logo, chat title, and display action */}
+        <MobileNav title={chat?.title ?? 'Chat'}>
+          <Button variant="ghost" size="icon" onClick={handleOpenDisplay}>
             <TvIcon className="h-4 w-4" />
-            <span className="hidden sm:inline">Display</span>
           </Button>
+        </MobileNav>
+
+        {/* Desktop: inline sidebar trigger + title + actions */}
+        <div className="hidden md:flex items-center gap-2 w-full">
+          <SidebarTrigger className="-ml-1" />
+          <Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
+          {chat && <EditableChatTitle chatId={chat.id} title={chat.title} />}
+          <div className="ml-auto flex items-center gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleOpenDisplay}
+              className="flex items-center gap-2"
+            >
+              <TvIcon className="h-4 w-4" />
+              <span>Display</span>
+            </Button>
+          </div>
         </div>
       </SidebarLayout.Header>
       <SidebarLayout.Content>

--- a/apps/web/components/nav/mobile.tsx
+++ b/apps/web/components/nav/mobile.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+
+import { SidebarTrigger } from '@september/ui/components/sidebar';
+
+import { cn } from '@september/shared/lib/utils';
+
+type MobileNavProps = {
+  title?: string | React.ReactNode;
+  children?: React.ReactNode;
+  className?: string;
+};
+
+export default function MobileNav({ title = 'September', children, className }: MobileNavProps) {
+  return (
+    <nav
+      className={cn(
+        'md:hidden flex items-center justify-between py-3 px-4 border-b w-full',
+        className
+      )}
+    >
+      <div className="flex items-center gap-3">
+        <Link href="/">
+          <Image src="/logo.png" alt="September" width={32} height={32} />
+        </Link>
+        <span className="font-semibold text-base truncate max-w-[180px]">{title}</span>
+      </div>
+
+      <div className="flex items-center gap-1">
+        {children}
+        <SidebarTrigger />
+      </div>
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary

- Add `apps/web/components/nav/mobile.tsx` — a `md:hidden` top bar showing the September logo, chat title, and an icon-only Display button
- Leverages the existing shadcn/ui `SidebarTrigger` (opens the Sheet sidebar on mobile) — no new navigation state
- Desktop header (`SidebarTrigger` + separator + `EditableChatTitle` + Display button) is unchanged behind `hidden md:flex`

## Test plan

- [ ] Open `/chats/[id]` at <768px viewport — verify logo + chat title + Display icon + hamburger are visible
- [ ] Tap hamburger — verify sidebar Sheet opens from the left
- [ ] At ≥768px — verify desktop header is unchanged