### PR TITLE
feat: audio output device selector

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1,0 +1,21 @@
+# TODOS
+
+Deferred work captured during reviews. Each item includes what, why, pros, cons, context, and dependencies so anyone picking it up in 3 months has the reasoning intact.
+
+## Voice cloning
+
+### Persist created voice_id locally + voice picker
+- **What:** After ElevenLabs returns a `voice_id`, persist `{voice_id, name, description, created_at}` in IndexedDB. Surface the list in `/settings/ai` and add a voice picker on `/talk` and `/write`.
+- **Why:** Today the clone disappears into a toast. The user has to remember the name and dig through ElevenLabs dashboard to reuse it. The feature is functionally dead without this follow-up — you cloned a voice but nothing in September can actually use it.
+- **Pros:** Unlocks the whole reason voice cloning exists. Users can select their own cloned voice for TTS playback. Unblocks multi-voice selection if the user clones more than one (e.g., "calm me", "excited me").
+- **Cons:** Needs UX decisions on picker placement, default voice, and what happens if the user deletes the voice in ElevenLabs but it still lives in September's store. Needs a schema for the persisted record and a migration path if that schema changes.
+- **Context:** Source code at [packages/cloning/components/form.tsx:87-89](packages/cloning/components/form.tsx#L87-L89) — today the `result.voice_id` is only shown in a toast and then forgotten. The cloning package already owns the storage primitive via [use-voice-storage.ts](packages/cloning/hooks/use-voice-storage.ts); extending it to store voice metadata is straightforward. See also [/settings/ai](apps/web/app/(app)/settings/) for where the API key lives — the voice list belongs nearby.
+- **Depends on / blocked by:** Voice cloning fix PR (current work) lands first.
+
+### Switch Control / single-button recording UX for ALS users
+- **What:** Redesign [packages/cloning/components/record.tsx](packages/cloning/components/record.tsx) so a single switch press can drive the whole flow: space-to-record → space-to-stop → space-to-next. Add dwell/delay tolerances for users with tremor or limited precision. Test end-to-end with macOS Switch Control and Voice Control.
+- **Why:** September's target users have ALS/MND. The current recording UI needs multiple precise button taps (Prev, Mic, Stop, Play, Trash, Next). For switch users or users with severe motor limitations, this is unusable. CLAUDE.md says the app is "for people with ALS, MND, or speech/motor difficulties" — the recording flow should match.
+- **Pros:** Makes voice cloning actually usable by the people who need it most. Reinforces September's core value.
+- **Cons:** Significant UX and accessibility work. Needs user testing with real AAC users. Likely needs a design review pass and VoiceOver/keyboard/Switch Control audit.
+- **Context:** See [apps/swift/docs/accessibility-implementation-guide.md](apps/swift/docs/accessibility-implementation-guide.md) for parallel Swift accessibility work — web flow should match conceptually. Switch Control test matrix should cover: auto-scan, single-switch, two-switch.
+- **Depends on / blocked by:** None — can start anytime. Should precede recommending voice cloning to end users.

--- a/packages/audio/components/audio-player.tsx
+++ b/packages/audio/components/audio-player.tsx
@@ -17,6 +17,11 @@ import {
 
 import { Audio as AudioTrack } from '@september/audio/types';
 
+interface AudioOutputDevice {
+  deviceId: string;
+  label: string;
+}
+
 // Context value type
 interface AudioPlayerContextType {
   isPlaying: boolean;
@@ -29,6 +34,11 @@ interface AudioPlayerContextType {
   currentTime: number;
   duration: number;
   seek: (time: number) => void;
+  // Audio output device selection
+  outputDevices: AudioOutputDevice[];
+  isDeviceSelectionSupported: boolean;
+  selectedOutputDeviceId: string;
+  setSelectedOutputDeviceId: (id: string) => void;
 }
 
 const AudioPlayerContext = createContext<AudioPlayerContextType | undefined>(undefined);
@@ -41,11 +51,29 @@ export function AudioPlayerProvider({ children }: { children: ReactNode }) {
   );
 }
 
+const AUDIO_OUTPUT_STORAGE_KEY = 'september:audio-output-device';
+
+const isDeviceSelectionSupported =
+  typeof navigator !== 'undefined' &&
+  typeof HTMLAudioElement !== 'undefined' &&
+  'setSinkId' in HTMLAudioElement.prototype;
+
 function AudioPlayerQueueProvider({ children }: { children: ReactNode }) {
   const [queue, setQueue] = useState<AudioTrack[]>([]);
   const [currentIndex, setCurrentIndex] = useState<number>(0);
   const [isMuted, setIsMuted] = useState(false);
   const [currentTime, setCurrentTime] = useState(0);
+  const [outputDevices, setOutputDevices] = useState<AudioOutputDevice[]>([]);
+  const [selectedOutputDeviceId, setSelectedOutputDeviceIdState] = useState<string>(() =>
+    typeof localStorage !== 'undefined'
+      ? (localStorage.getItem(AUDIO_OUTPUT_STORAGE_KEY) ?? '')
+      : ''
+  );
+  const sinkAudioRef = useRef<HTMLAudioElement | null>(null);
+  // State for sinkId audio element (separate from react-use-audio-player)
+  const [isSinkPlaying, setIsSinkPlaying] = useState(false);
+  const [sinkDuration, setSinkDuration] = useState(0);
+  const [sinkCurrentTime, setSinkCurrentTime] = useState(0);
 
   const {
     load,
@@ -58,7 +86,7 @@ function AudioPlayerQueueProvider({ children }: { children: ReactNode }) {
   } = useAudioPlayerContext();
   const synthesis = typeof window !== 'undefined' ? window.speechSynthesis : null;
 
-  // RAF-based time tracking with throttling to reduce re-renders
+  // RAF-based time tracking for react-use-audio-player path
   // Only updates state when position changes by more than threshold
   const rafRef = useRef<number | null>(null);
   const lastReportedTime = useRef<number>(0);
@@ -95,11 +123,40 @@ function AudioPlayerQueueProvider({ children }: { children: ReactNode }) {
 
   const seek = useCallback(
     (time: number) => {
-      audioSeek(time);
-      setCurrentTime(time);
+      if (sinkAudioRef.current && isSinkPlaying) {
+        sinkAudioRef.current.currentTime = time;
+        setSinkCurrentTime(time);
+      } else {
+        audioSeek(time);
+        setCurrentTime(time);
+      }
     },
-    [audioSeek]
+    [audioSeek, isSinkPlaying]
   );
+
+  // Enumerate audio output devices; re-enumerate when devices change
+  useEffect(() => {
+    if (!isDeviceSelectionSupported) return;
+    const enumerate = () =>
+      navigator.mediaDevices.enumerateDevices().then(devices => {
+        setOutputDevices(
+          devices
+            .filter(d => d.kind === 'audiooutput' && d.deviceId)
+            .map((d, i) => ({ deviceId: d.deviceId, label: d.label || `Speaker ${i + 1}` }))
+        );
+      });
+    enumerate();
+    navigator.mediaDevices.addEventListener('devicechange', enumerate);
+    return () => navigator.mediaDevices.removeEventListener('devicechange', enumerate);
+  }, []);
+
+  // Stop sinkId audio on unmount
+  useEffect(() => () => { sinkAudioRef.current?.pause(); }, []);
+
+  const setSelectedOutputDeviceId = useCallback((id: string) => {
+    localStorage.setItem(AUDIO_OUTPUT_STORAGE_KEY, id);
+    setSelectedOutputDeviceIdState(id);
+  }, []);
 
   useEffect(() => {
     if (queue.length > 0 && queue[currentIndex]) {
@@ -128,24 +185,40 @@ function AudioPlayerQueueProvider({ children }: { children: ReactNode }) {
 
       if (track.blob) {
         const blob = queue[currentIndex].blob;
-
         const src = blob?.startsWith('data:') ? blob : `data:audio/mp3;base64,${blob}`;
-        load(src, {
-          autoplay: true,
-          onend: () => {
-            // When the track ends, move to the next one
-            if (currentIndex < queue.length - 1) {
-              setCurrentIndex(idx => idx + 1);
-            } else {
-              // Optionally, clear the queue or reset index
-              setQueue([]);
-              setCurrentIndex(0);
-            }
-          },
-        });
+
+        const advance = () => {
+          setIsSinkPlaying(false);
+          if (currentIndex < queue.length - 1) {
+            setCurrentIndex(idx => idx + 1);
+          } else {
+            setQueue([]);
+            setCurrentIndex(0);
+          }
+        };
+
+        if (selectedOutputDeviceId) {
+          sinkAudioRef.current?.pause();
+          const audioEl = new Audio(src);
+          sinkAudioRef.current = audioEl;
+          audioEl.onplay = () => setIsSinkPlaying(true);
+          audioEl.onpause = () => setIsSinkPlaying(false);
+          audioEl.ondurationchange = () => setSinkDuration(audioEl.duration);
+          audioEl.ontimeupdate = () => setSinkCurrentTime(audioEl.currentTime);
+          audioEl.onended = advance;
+          (audioEl as HTMLAudioElement & { setSinkId(id: string): Promise<void> })
+            .setSinkId(selectedOutputDeviceId)
+            .then(() => audioEl.play())
+            .catch(err => {
+              console.error('setSinkId failed, falling back to default device:', err);
+              audioEl.play();
+            });
+        } else {
+          load(src, { autoplay: true, onend: advance });
+        }
       }
     }
-  }, [queue, currentIndex, load, synthesis]);
+  }, [queue, currentIndex, load, synthesis, selectedOutputDeviceId]);
 
   // Enqueue a new track
   const enqueue = useCallback(
@@ -166,29 +239,38 @@ function AudioPlayerQueueProvider({ children }: { children: ReactNode }) {
     [isMuted]
   );
 
-  // Toggle play/pause
+  // Toggle play/pause — handles both sinkId and react-use-audio-player paths
   const togglePlayPause = useCallback(() => {
-    if (isPlaying) {
+    if (sinkAudioRef.current && isSinkPlaying) {
+      sinkAudioRef.current.pause();
+    } else if (sinkAudioRef.current && !isSinkPlaying && sinkAudioRef.current.src) {
+      sinkAudioRef.current.play();
+    } else if (isPlaying) {
       pause();
     } else {
       play();
     }
-  }, [isPlaying, play, pause]);
+  }, [isPlaying, isSinkPlaying, play, pause]);
 
   const toggleMute = useCallback(() => {
     setIsMuted(prev => !prev);
   }, []);
 
+  // Merge state: sinkId path takes precedence when active
   const value: AudioPlayerContextType = {
-    isPlaying,
+    isPlaying: isSinkPlaying || isPlaying,
     enqueue,
     togglePlayPause,
     current: queue[currentIndex] || undefined,
     isMuted,
     toggleMute,
-    currentTime,
-    duration,
+    currentTime: isSinkPlaying ? sinkCurrentTime : currentTime,
+    duration: isSinkPlaying ? sinkDuration : duration,
     seek,
+    outputDevices,
+    isDeviceSelectionSupported,
+    selectedOutputDeviceId,
+    setSelectedOutputDeviceId,
   };
 
   return <AudioPlayerContext.Provider value={value}>{children}</AudioPlayerContext.Provider>;
@@ -199,4 +281,3 @@ export function useAudioPlayer() {
   if (!ctx) throw new Error('useAudioPlayer must be used within AudioPlayerProvider');
   return ctx;
 }
-

--- a/packages/audio/hooks/use-audio-output-devices.test.ts
+++ b/packages/audio/hooks/use-audio-output-devices.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+// Pure helpers extracted from audio-player logic for isolated testing.
+// These mirror the exact patterns used inside AudioPlayerQueueProvider.
+
+const STORAGE_KEY = 'september:audio-output-device';
+
+function filterAndMapAudioOutputDevices(devices: MediaDeviceInfo[]): { deviceId: string; label: string }[] {
+  return devices
+    .filter(d => d.kind === 'audiooutput' && d.deviceId)
+    .map((d, i) => ({ deviceId: d.deviceId, label: d.label || `Speaker ${i + 1}` }));
+}
+
+function makeDevice(overrides: Partial<MediaDeviceInfo>): MediaDeviceInfo {
+  return {
+    deviceId: 'id-1',
+    groupId: 'group-1',
+    kind: 'audiooutput',
+    label: '',
+    toJSON: () => ({}),
+    ...overrides,
+  } as MediaDeviceInfo;
+}
+
+// ────────────────────────────────────────────────────────
+// Device enumeration filtering
+// ────────────────────────────────────────────────────────
+
+describe('filterAndMapAudioOutputDevices', () => {
+  it('filters out non-audiooutput devices', () => {
+    const devices = [
+      makeDevice({ kind: 'audioinput', deviceId: 'mic-1', label: 'Microphone' }),
+      makeDevice({ kind: 'videoinput', deviceId: 'cam-1', label: 'Camera' }),
+      makeDevice({ kind: 'audiooutput', deviceId: 'spk-1', label: 'Speaker' }),
+    ];
+    const result = filterAndMapAudioOutputDevices(devices);
+    expect(result).toHaveLength(1);
+    expect(result[0].deviceId).toBe('spk-1');
+  });
+
+  it('filters out devices with empty deviceId', () => {
+    const devices = [
+      makeDevice({ kind: 'audiooutput', deviceId: '', label: 'Default' }),
+      makeDevice({ kind: 'audiooutput', deviceId: 'spk-1', label: 'Speaker' }),
+    ];
+    const result = filterAndMapAudioOutputDevices(devices);
+    expect(result).toHaveLength(1);
+    expect(result[0].deviceId).toBe('spk-1');
+  });
+
+  it('uses device label when available', () => {
+    const devices = [
+      makeDevice({ kind: 'audiooutput', deviceId: 'spk-1', label: 'Bluetooth Headset' }),
+    ];
+    const result = filterAndMapAudioOutputDevices(devices);
+    expect(result[0].label).toBe('Bluetooth Headset');
+  });
+
+  it('uses positional fallback label when label is empty (no mic permission)', () => {
+    const devices = [
+      makeDevice({ kind: 'audiooutput', deviceId: 'spk-1', label: '' }),
+      makeDevice({ kind: 'audiooutput', deviceId: 'spk-2', label: '' }),
+    ];
+    const result = filterAndMapAudioOutputDevices(devices);
+    expect(result[0].label).toBe('Speaker 1');
+    expect(result[1].label).toBe('Speaker 2');
+  });
+
+  it('returns empty array when no audiooutput devices', () => {
+    const devices = [
+      makeDevice({ kind: 'audioinput', deviceId: 'mic-1', label: 'Microphone' }),
+    ];
+    expect(filterAndMapAudioOutputDevices(devices)).toHaveLength(0);
+  });
+});
+
+// ────────────────────────────────────────────────────────
+// localStorage persistence
+// ────────────────────────────────────────────────────────
+
+describe('audio output device localStorage', () => {
+  let store: Record<string, string> = {};
+  const mockStorage = {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value; },
+    removeItem: (key: string) => { delete store[key]; },
+  };
+
+  beforeEach(() => {
+    store = {};
+    vi.stubGlobal('localStorage', mockStorage);
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('initializes to empty string when nothing is stored', () => {
+    const stored = localStorage.getItem(STORAGE_KEY) ?? '';
+    expect(stored).toBe('');
+  });
+
+  it('persists selected device id', () => {
+    localStorage.setItem(STORAGE_KEY, 'spk-abc');
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('spk-abc');
+  });
+
+  it('clears selection when set to empty string', () => {
+    localStorage.setItem(STORAGE_KEY, 'spk-abc');
+    localStorage.setItem(STORAGE_KEY, '');
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('');
+  });
+
+  it('reads back the last saved device id', () => {
+    localStorage.setItem(STORAGE_KEY, 'spk-first');
+    localStorage.setItem(STORAGE_KEY, 'spk-second');
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('spk-second');
+  });
+});
+
+// ────────────────────────────────────────────────────────
+// setSinkId fallback behavior
+// ────────────────────────────────────────────────────────
+
+describe('setSinkId fallback', () => {
+  it('falls back to play() without sink if setSinkId rejects', async () => {
+    const play = vi.fn().mockResolvedValue(undefined);
+    const setSinkId = vi.fn().mockRejectedValue(new Error('Device not found'));
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    // Simulate the setSinkId + fallback pattern from audio-player.tsx
+    await setSinkId('missing-device-id')
+      .then(() => play())
+      .catch(err => {
+        console.error('setSinkId failed, falling back to default device:', err);
+        play();
+      });
+
+    expect(setSinkId).toHaveBeenCalledWith('missing-device-id');
+    expect(play).toHaveBeenCalledTimes(1); // fallback play, not the .then() play
+    expect(consoleError).toHaveBeenCalled();
+
+    consoleError.mockRestore();
+  });
+
+  it('plays via setSinkId when it succeeds', async () => {
+    const play = vi.fn().mockResolvedValue(undefined);
+    const setSinkId = vi.fn().mockResolvedValue(undefined);
+
+    await setSinkId('valid-device-id')
+      .then(() => play())
+      .catch(() => play());
+
+    expect(setSinkId).toHaveBeenCalledWith('valid-device-id');
+    expect(play).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ────────────────────────────────────────────────────────
+// __default__ sentinel (SpeechSettingsForm ↔ useAudioPlayer bridge)
+// ────────────────────────────────────────────────────────
+
+describe('__default__ sentinel conversion', () => {
+  // Mirrors the onValueChange logic in SpeechSettingsForm
+  const convert = (id: string) => (id === '__default__' ? '' : id);
+  const display = (id: string) => id || '__default__';
+
+  it('converts __default__ to empty string for storage', () => {
+    expect(convert('__default__')).toBe('');
+  });
+
+  it('converts real device id unchanged', () => {
+    expect(convert('spk-abc')).toBe('spk-abc');
+  });
+
+  it('displays empty string as __default__ in the Select', () => {
+    expect(display('')).toBe('__default__');
+  });
+
+  it('displays real device id unchanged', () => {
+    expect(display('spk-abc')).toBe('spk-abc');
+  });
+});

--- a/packages/speech/components/speech-settings-form.tsx
+++ b/packages/speech/components/speech-settings-form.tsx
@@ -5,6 +5,8 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { FormCheckbox, FormSelect, FormSlider } from '@september/ui/components/form';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@september/ui/components/select';
+import { useAudioPlayer } from '@september/audio';
 import { toast } from 'sonner';
 import { getModelsForProvider, getProvidersForFeature } from '@september/ai';
 import type { Account } from '@september/account';
@@ -96,6 +98,9 @@ export function SpeechSettingsForm({ account, onSubmit, children }: SpeechSettin
   const provider = form.watch('provider');
   const selectedVoiceId = form.watch('voice_id');
   const selectedVoiceName = form.watch('voice_name');
+
+  const { outputDevices, isDeviceSelectionSupported, selectedOutputDeviceId, setSelectedOutputDeviceId } =
+    useAudioPlayer();
 
   // Get speech providers from registry
   const speechProviders = useMemo(() => {
@@ -521,6 +526,41 @@ export function SpeechSettingsForm({ account, onSubmit, children }: SpeechSettin
                 />
               </div>
             </div>
+          </div>
+        </div>
+      )}
+
+      {/* Audio Output Device */}
+      {isDeviceSelectionSupported && (
+        <div className="border-t border-zinc-200 pt-6">
+          <div className="px-4 mb-4">
+            <h3 className="text-base/7 font-semibold text-zinc-900">Audio Output Device</h3>
+            <p className="mt-1 text-sm/6 text-zinc-600">
+              Choose which speaker plays speech. Saved locally on this device.
+            </p>
+            {provider === 'browser' && (
+              <p className="mt-1 text-sm text-amber-700">
+                Browser TTS uses the system default regardless of this setting.
+              </p>
+            )}
+          </div>
+          <div className="px-4">
+            <Select
+              value={selectedOutputDeviceId || '__default__'}
+              onValueChange={id => setSelectedOutputDeviceId(id === '__default__' ? '' : id)}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="System Default" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__default__">System Default</SelectItem>
+                {outputDevices.map(device => (
+                  <SelectItem key={device.deviceId} value={device.deviceId}>
+                    {device.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
         </div>
       )}

--- a/packages/suggestions/README.md
+++ b/packages/suggestions/README.md
@@ -4,7 +4,7 @@ The Suggestions module provides AI-powered typing suggestions and search history
 
 ## Features
 
-- **AI Suggestions**: Real-time sentence and phrase completions using Gemini API.
+- **AI Suggestions**: Real-time sentence and phrase completions using Gemini API. Refetches for every new message in the conversation; stale in-flight responses are dropped so the list always reflects the latest message.
 - **Search History**: Retrieving past messages as suggestions.
 - **Configurable**: Settings for model selection, system instructions, and content corpus.
 

--- a/packages/suggestions/hooks/use-suggestions.ts
+++ b/packages/suggestions/hooks/use-suggestions.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { z } from 'zod';
 
@@ -8,17 +8,22 @@ import { useAISettings, useGenerate } from '@september/ai';
 import { Message } from '@september/chats';
 import { Suggestion } from '@september/suggestions/types';
 
-const SUGGESTIONS_PROMPT = `Generate 5 possible NEXT messages for the User to send in the conversation.
+const SUGGESTIONS_PROMPT = `Generate 5 possible NEXT things the User might WANT TO SAY to the person they are speaking with.
 
 <context>
-- Suggestions are triggered AFTER the User sends a message
-- The User has just sent their last message and is now waiting or ready to respond to what comes next
-- Generate what the User would MOST LIKELY say next as a follow-up or response
+- The User is a person with speech or motor difficulties using an assistive communication app to speak out loud to someone in front of them
+- The "Me:" lines below are things the User has already said through the app
+- "Them:" lines (if any) are transcriptions of the other person's speech — these are often MISSING because transcription is optional, so most of the time you will only see the User's own utterances
+- Because the other side is usually invisible, DO NOT assume the User is answering a question. Assume they are driving the conversation forward and need help saying their NEXT thing
+- Think of suggestions as "what would this person most plausibly want to say next to keep this conversation going?"
 </context>
 
 <rules>
-- Suggestions must be the User's NEXT message, not a continuation of their previous one
-- Generate natural follow-ups or responses based on the conversation flow
+- Suggestions must be things the User (Me) would say out loud next — never replies FROM the other person
+- Do NOT generate answers to a question the User just asked (they asked it, they don't need to answer it)
+- Prefer natural continuations of the User's own thread: follow-up questions they might ask, additional things they might add, new related topics, closers, clarifications, or small talk that fits the moment
+- Keep suggestions short, speakable, and natural — this is spoken conversation, not written text
+- Offer variety across the 5 suggestions (e.g. one question, one statement, one topic shift) so the User has real choices
 - Match the User's tone and style from the persona
 - STRICTLY maintain the same language as the conversation context
 - Return ONLY a JSON array of 5 strings, no other text
@@ -30,17 +35,27 @@ const SUGGESTIONS_PROMPT = `Generate 5 possible NEXT messages for the User to se
 
 <examples>
 <example>
+<description>Only the User's side is visible — the common case. Suggestions continue the User's thread, they do NOT answer "How are you today?" because the User asked that, not the other person.</description>
 <input>
-Them: Want to grab dinner tonight?
-Me: Sure, sounds good!
+Me: How are you today?
+Me: It's good to see you
 </input>
-<output>["What time works for you?", "Where should we go?", "I know a great place nearby", "Let me check my schedule", "Should we invite anyone else?"]</output>
+<output>["It's been a while", "What have you been up to?", "You look great", "Do you have time to catch up?", "Tell me what's new with you"]</output>
 </example>
 <example>
+<description>User is opening a conversation with a single greeting. Suggestions are natural next things to say, not responses.</description>
 <input>
-Them: How are you?
+Me: Hello
 </input>
-<output>["I'm doing well, thanks!", "I'm good, how about you?", "I'm okay, just tired", "I'm great!", "Hanging in there"]</output>
+<output>["How have you been?", "Thanks for coming over", "I wanted to talk with you", "Can you sit with me for a bit?", "It's good to see you"]</output>
+</example>
+<example>
+<description>Transcription of the other person is available — treat it as context but still generate the User's NEXT utterance.</description>
+<input>
+Me: How was your trip?
+Them: It was amazing, we spent a week in the mountains
+</input>
+<output>["That sounds wonderful", "Which mountains did you visit?", "Did you hike much?", "I'd love to see photos", "Was the weather good?"]</output>
 </example>
 </examples>`;
 
@@ -65,6 +80,9 @@ export function useSuggestions({
 }): UseSuggestionsReturn {
   const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+  const requestIdRef = useRef(0);
+  const historyRef = useRef(history);
+  historyRef.current = history;
 
   const { suggestionsConfig } = useAISettings();
   const { generate, isReady } = useGenerate({
@@ -76,64 +94,60 @@ export function useSuggestions({
     setSuggestions([]);
   }, []);
 
-  // Auto-fetch suggestions when history changes (e.g. new message received)
+  // Re-fetch suggestions whenever the latest message changes. Keying on the
+  // last message id (a stable primitive) guarantees a refetch for every new
+  // message — even if one arrives while a previous fetch is still in flight.
+  const lastMessageId = history[history.length - 1]?.id;
+
   useEffect(() => {
-    if (history.length === 0 || !isReady) {
-      if (history.length === 0) {
-        setSuggestions([]);
-      }
+    if (!lastMessageId || !isReady || !suggestionsConfig.enabled) {
+      setSuggestions([]);
       return;
     }
 
-    if (isLoading || !suggestionsConfig.enabled) {
-      return;
-    }
+    const requestId = ++requestIdRef.current;
+    setSuggestions([]);
+    setIsLoading(true);
 
-    const fetchSuggestions = async (messages: Message[]) => {
-      setIsLoading(true);
+    const messagesContent = historyRef.current
+      .map(m => `${m.type === 'transcription' ? 'Them' : 'Me'}: ${m.text}`)
+      .join('\n');
 
-      try {
-        const messagesContent = messages
-          .map(m => `${m.type === 'transcription' ? 'Them' : 'Me'}: ${m.text}`)
-          .join('\n');
-
-        const result = await generate({
-          prompt: `Context: ${context}\nConversation:\n${messagesContent}`,
-          system: SUGGESTIONS_PROMPT.replace(
-            '{USER_PERSONA}',
-            suggestionsConfig.settings?.system_instructions || ''
-          ),
-        });
-
+    generate({
+      prompt: `Context: ${context}\nConversation:\n${messagesContent}`,
+      system: SUGGESTIONS_PROMPT.replace(
+        '{USER_PERSONA}',
+        suggestionsConfig.settings?.system_instructions || ''
+      ),
+    })
+      .then((result: string | undefined) => {
+        // Drop stale responses — only the latest in-flight request wins.
+        if (requestId !== requestIdRef.current) return;
         if (result) {
           try {
-            const suggestions = JSON.parse(
+            const parsed = JSON.parse(
               result.replace('```json', '').replace('```', '').trim()
             ) as string[];
             setSuggestions(
-              suggestions.map((suggestionText: string) => ({
-                text: suggestionText,
-                audio_path: undefined,
-              }))
+              parsed.map((text: string) => ({ text, audio_path: undefined }))
             );
           } catch (error) {
-            throw error;
+            console.error('Error parsing suggestions:', error);
           }
         }
-      } catch (error) {
-        console.error('Error fetching suggestions:', error);
-      } finally {
         setIsLoading(false);
-      }
-    };
-
-    fetchSuggestions(history);
+      })
+      .catch((error: unknown) => {
+        if (requestId !== requestIdRef.current) return;
+        console.error('Error fetching suggestions:', error);
+        setIsLoading(false);
+      });
   }, [
+    lastMessageId,
     isReady,
     suggestionsConfig.enabled,
-    suggestionsConfig.model,
     suggestionsConfig.settings?.system_instructions,
-    history,
+    context,
     generate,
   ]);
 


### PR DESCRIPTION
## Summary

- Adds an **Audio Output Device** picker to the Speech Settings modal, letting users route TTS audio to a specific speaker (e.g. external speaker facing others vs. earpiece). Selection persists in `localStorage` — machine-local, not synced to account DB.
- Extends `useAudioPlayer` with device enumeration, state sync, and a two-path blob playback strategy: `react-use-audio-player` for system default, raw `HTMLAudioElement` + `setSinkId` for a selected device.
- Browser TTS (`SpeechSynthesis`) is unaffected and shows an amber note in the UI.

## Changes

**`packages/audio/components/audio-player.tsx`**
- `AudioPlayerContextType` extended: `outputDevices`, `isDeviceSelectionSupported`, `selectedOutputDeviceId`, `setSelectedOutputDeviceId`
- Device enumeration via `navigator.mediaDevices.enumerateDevices()` with `devicechange` listener for hot-plug support
- Positional fallback labels (`Speaker 1`, `Speaker 2`) when mic permission not granted
- sinkId playback path: `HTMLAudioElement` + `setSinkId`, with `onplay`/`onpause`/`ondurationchange`/`ontimeupdate` handlers to keep `isPlaying`/`duration`/`currentTime`/`seek`/`togglePlayPause` in sync
- `setSinkId` rejection falls back to system default (no silent failures)
- Unmount cleanup for `sinkAudioRef`

**`packages/speech/components/speech-settings-form.tsx`**
- Audio Output Device section added at the bottom of the form (after Kokoro settings)
- Uses shadcn `Select` directly (outside form schema — saves instantly on change)
- `__default__` sentinel handles Radix Select's empty-string restriction

**`packages/audio/hooks/use-audio-output-devices.test.ts`** (new)
- 15 tests: device filtering, positional labels, localStorage read/write, `setSinkId` fallback, sentinel conversion

## Test plan

- [ ] Open Speech Settings modal → "Audio Output Device" section visible at bottom (Chromium only)
- [ ] Select a non-default device → reload → device still selected
- [ ] Send message via ElevenLabs/Gemini/Kokoro → audio plays on selected device
- [ ] Pause button works while playing on non-default device
- [ ] Unplug selected device, send message → falls back to system default, no silent failure
- [ ] Plug in new device mid-session → appears in dropdown immediately
- [ ] Browser TTS shows amber note, plays on system default regardless of selection
- [ ] Firefox (no `setSinkId`) → Audio Output section hidden
- [ ] `pnpm vitest run packages/audio/hooks/use-audio-output-devices.test.ts` → 15/15 green