### PR TITLE
fix(cloning): fix P1 bugs in voice cloning flow

### DIFF
--- a/apps/web/app/(app)/voices/layout.tsx
+++ b/apps/web/app/(app)/voices/layout.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Voices',
+  description: 'Browse and find voices similar to your cloned voice.',
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/apps/web/app/(app)/voices/page.tsx
+++ b/apps/web/app/(app)/voices/page.tsx
@@ -1,0 +1,200 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { useSearchParams } from 'next/navigation';
+
+import { useAccountContext } from '@september/account';
+import { CloningProvider, useVoiceStorageContext } from '@september/cloning';
+import { ElevenLabsVoiceClone, SimilarVoice } from '@september/cloning/lib/elevenlabs-clone';
+import { Button } from '@september/ui/components/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@september/ui/components/card';
+import { Separator } from '@september/ui/components/separator';
+import { SidebarTrigger } from '@september/ui/components/sidebar';
+
+import SidebarLayout from '@/components/sidebar/layout';
+
+function SimilarVoicesContent() {
+  const searchParams = useSearchParams();
+  const isSimilarSearch = searchParams.get('search') === 'similar';
+
+  const { account } = useAccountContext();
+  const { getVoiceSamples, downloadVoiceSample } = useVoiceStorageContext();
+
+  const [results, setResults] = useState<SimilarVoice[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [hasSamples, setHasSamples] = useState<boolean | null>(null);
+
+  const elevenlabsApiKey = useMemo(
+    () => account?.ai_providers?.elevenlabs?.api_key,
+    [account]
+  );
+
+  // Check if the user has any stored samples on mount
+  useEffect(() => {
+    if (!isSimilarSearch) return;
+    getVoiceSamples().then(samples => setHasSamples(samples.length > 0));
+  }, [isSimilarSearch, getVoiceSamples]);
+
+  const handleSearch = useCallback(async () => {
+    if (!elevenlabsApiKey) return;
+
+    setIsSearching(true);
+    setError(null);
+
+    try {
+      const samples = await getVoiceSamples();
+
+      if (samples.length === 0) {
+        setError('No voice samples found. Record or upload samples on the Clone page first.');
+        return;
+      }
+
+      const files = await Promise.all(
+        samples.map(async sample => {
+          const blob = await downloadVoiceSample(sample.id);
+          const parts = sample.id.split('/');
+          const filename = parts[parts.length - 1] || `sample-${sample.id}.webm`;
+          return new File([blob], filename, { type: blob.type || 'audio/webm' });
+        })
+      );
+
+      const cloneService = new ElevenLabsVoiceClone(elevenlabsApiKey);
+      const voices = await cloneService.findSimilarVoices(files);
+      setResults(voices);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to find similar voices');
+    } finally {
+      setIsSearching(false);
+    }
+  }, [elevenlabsApiKey, getVoiceSamples, downloadVoiceSample]);
+
+  // Auto-trigger the search when the page loads with ?search=similar
+  const didAutoSearch = useRef(false);
+  useEffect(() => {
+    if (isSimilarSearch && elevenlabsApiKey && hasSamples && !didAutoSearch.current) {
+      didAutoSearch.current = true;
+      handleSearch();
+    }
+  }, [isSimilarSearch, elevenlabsApiKey, hasSamples, handleSearch]);
+
+  if (!isSimilarSearch) {
+    return (
+      <div className="space-y-6 max-w-2xl">
+        <Card>
+          <CardHeader>
+            <CardTitle>Voices</CardTitle>
+            <CardDescription>
+              Find ElevenLabs library voices that sound similar to yours.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button asChild>
+              <a href="/voices?search=similar">Find Similar Voices</a>
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6 max-w-2xl">
+      {!elevenlabsApiKey && (
+        <Card className="border-amber-200 bg-amber-50">
+          <CardContent className="pt-6">
+            <p className="text-sm text-amber-800">
+              <strong>API Key Required:</strong> Configure your ElevenLabs API key in{' '}
+              <a href="/settings/ai" className="underline hover:text-amber-900">
+                AI Settings
+              </a>{' '}
+              to search for similar voices.
+            </p>
+          </CardContent>
+        </Card>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Find Similar Voices</CardTitle>
+          <CardDescription>
+            ElevenLabs library voices that sound closest to your recorded samples.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {hasSamples === false && (
+            <p className="text-sm text-muted-foreground">
+              No voice samples found.{' '}
+              <a href="/clone" className="underline">
+                Record or upload samples
+              </a>{' '}
+              on the Clone page first.
+            </p>
+          )}
+
+          {error && <p className="text-sm text-destructive">{error}</p>}
+
+          <Button
+            onClick={handleSearch}
+            disabled={isSearching || !elevenlabsApiKey || hasSamples === false}
+          >
+            {isSearching ? 'Searching...' : 'Search Again'}
+          </Button>
+
+          {results.length > 0 && (
+            <ul className="mt-4 divide-y">
+              {results.map(voice => (
+                <li key={voice.voice_id} className="py-4 space-y-1">
+                  <div className="flex items-center justify-between gap-4">
+                    <div className="space-y-0.5">
+                      <p className="text-sm font-medium">{voice.name}</p>
+                      {voice.description && (
+                        <p className="text-xs text-muted-foreground">{voice.description}</p>
+                      )}
+                      {voice.similarity_score !== undefined && (
+                        <p className="text-xs text-muted-foreground">
+                          Similarity: {Math.round(voice.similarity_score * 100)}%
+                        </p>
+                      )}
+                    </div>
+                    {voice.preview_url && (
+                      <audio
+                        controls
+                        src={voice.preview_url}
+                        className="h-8 w-48 shrink-0"
+                        aria-label={`Preview ${voice.name}`}
+                      />
+                    )}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {!isSearching && results.length === 0 && hasSamples && !error && (
+            <p className="text-sm text-muted-foreground">
+              No similar voices found. Try adding more samples for a better match.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default function VoicesPage() {
+  return (
+    <>
+      <SidebarLayout.Header>
+        <SidebarTrigger className="-ml-1" />
+        <Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
+      </SidebarLayout.Header>
+      <SidebarLayout.Content>
+        <CloningProvider>
+          <SimilarVoicesContent />
+        </CloningProvider>
+      </SidebarLayout.Content>
+    </>
+  );
+}

--- a/packages/audio/lib/audio-service.test.ts
+++ b/packages/audio/lib/audio-service.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Regression tests for AudioService
+ *
+ * REGRESSION: uploadAudioBinary must accept a Blob/ArrayBuffer and store it without
+ * the base64 `String.fromCharCode(...new Uint8Array(buf))` spread that overflows the
+ * call stack for any file larger than ~65 KB (V8 argument limit).
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import 'fake-indexeddb/auto';
+
+import { AudioService } from './audio-service';
+
+describe('AudioService', () => {
+  let service: AudioService;
+
+  beforeEach(() => {
+    service = new AudioService();
+  });
+
+  // REGRESSION: The original uploadAudio(base64 string) path does:
+  //   btoa(String.fromCharCode(...new Uint8Array(arrayBuffer)))
+  // This blows the call stack for any real audio file.
+  // uploadAudioBinary must round-trip without throwing.
+  it('uploadAudioBinary stores and retrieves a 1 MB Blob without stack overflow', async () => {
+    const oneMB = new Uint8Array(1024 * 1024).fill(42);
+    const blob = new Blob([oneMB], { type: 'audio/webm' });
+
+    await expect(
+      service.uploadAudioBinary({
+        path: 'voice-samples/user/upload/test.webm',
+        blob,
+        contentType: 'audio/webm',
+      })
+    ).resolves.toBe('voice-samples/user/upload/test.webm');
+  });
+
+  it('uploadAudioBinary round-trips the blob content correctly', async () => {
+    const data = new Uint8Array([1, 2, 3, 4, 5]);
+    const blob = new Blob([data], { type: 'audio/webm' });
+
+    await service.uploadAudioBinary({
+      path: 'test/sample.webm',
+      blob,
+      contentType: 'audio/webm',
+    });
+
+    const retrieved = await service.downloadAudio('test/sample.webm');
+    const buf = await retrieved.arrayBuffer();
+    expect(new Uint8Array(buf)).toEqual(data);
+  });
+
+  it('uploadAudioBinary stores metadata and is listed by prefix', async () => {
+    const blob = new Blob([new Uint8Array(16)], { type: 'audio/webm' });
+
+    await service.uploadAudioBinary({
+      path: 'voice-samples/user123/recording/sample-a.webm',
+      blob,
+      contentType: 'audio/webm',
+      metadata: { user_id: 'user123', type: 'recording', sample_id: 'sample-a' },
+    });
+
+    const files = await service.listAudio('voice-samples/user123/recording');
+    expect(files.length).toBeGreaterThanOrEqual(1);
+    expect(files[0].metadata.user_id).toBe('user123');
+    expect(files[0].metadata.sample_id).toBe('sample-a');
+  });
+
+  it('uploadAudioBinary accepts ArrayBuffer as well as Blob', async () => {
+    const buffer = new Uint8Array([10, 20, 30]).buffer;
+
+    await expect(
+      service.uploadAudioBinary({
+        path: 'test/arraybuffer.webm',
+        blob: buffer,
+        contentType: 'audio/webm',
+      })
+    ).resolves.toBe('test/arraybuffer.webm');
+  });
+
+  // Keep legacy uploadAudio (base64 string) working for existing callers (TTS, chats)
+  it('legacy uploadAudio(base64 string) still works for small payloads', async () => {
+    const data = new Uint8Array([1, 2, 3]);
+    const base64 = btoa(String.fromCharCode(...data));
+
+    await service.uploadAudio({
+      path: 'test/small.mp3',
+      blob: base64,
+      contentType: 'audio/mp3',
+    });
+
+    const retrieved = await service.downloadAudio('test/small.mp3');
+    const buf = await retrieved.arrayBuffer();
+    expect(new Uint8Array(buf)).toEqual(data);
+  });
+});

--- a/packages/audio/lib/audio-service.ts
+++ b/packages/audio/lib/audio-service.ts
@@ -14,6 +14,43 @@ const kvStore = typeof indexedDB !== 'undefined'
   : null;
 
 export class AudioService {
+  /**
+   * Store a Blob or ArrayBuffer directly — no base64 encoding.
+   *
+   * Prefer this over uploadAudio() for any caller that already has binary data
+   * (file uploads, MediaRecorder blobs, fetch responses). The legacy uploadAudio()
+   * accepts a base64 string for backwards-compat with TTS callers.
+   */
+  async uploadAudioBinary({
+    path,
+    blob,
+    contentType = 'audio/webm',
+    metadata = {},
+  }: {
+    path: string;
+    blob: Blob | ArrayBuffer;
+    contentType?: string;
+    metadata?: Record<string, unknown>;
+  }): Promise<string> {
+    if (!kvStore) return path;
+
+    const buffer = blob instanceof Blob ? await blob.arrayBuffer() : blob;
+    const item: StoredAudioItem = {
+      blob: buffer,
+      contentType,
+      metadata,
+      created_at: new Date().toISOString(),
+      name: path.split('/').pop() || path,
+    };
+
+    await kvStore.set(path, item);
+    return path;
+  }
+
+  /**
+   * Legacy upload path for callers that produce base64 strings (TTS, chats).
+   * New callers should use uploadAudioBinary() instead.
+   */
   async uploadAudio({
     path,
     blob,

--- a/packages/audio/vitest.config.ts
+++ b/packages/audio/vitest.config.ts
@@ -1,0 +1,18 @@
+import path from 'path';
+
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    // AudioService uses IndexedDB (fake-indexeddb) but no DOM APIs.
+    // Run in node environment so Blob.arrayBuffer() is available (jsdom omits it).
+    environment: 'node',
+  },
+  resolve: {
+    alias: {
+      '@september/audio': path.resolve(__dirname, '.'),
+      '@september/shared': path.resolve(__dirname, '../shared'),
+    },
+  },
+});

--- a/packages/cloning/README.md
+++ b/packages/cloning/README.md
@@ -1,50 +1,62 @@
 # Cloning Module
 
-This module provides functionality for voice cloning, specifically using the ElevenLabs API. It includes components for uploading audio files, recording voice samples, and a form to submit these samples for cloning.
+Voice cloning for the September app using the ElevenLabs API. Users can upload existing audio or record new samples directly in the browser, then submit them to ElevenLabs to create a personal voice clone.
 
 ## Features
 
-- **Audio Upload**: Upload existing audio files for voice cloning.
-- **Voice Recording**: Record voice samples directly in the browser using pre-defined sample texts.
-- **ElevenLabs Integration**: Integration with the ElevenLabs API for creating voice clones.
-- **Local Storage**: Voice samples are stored locally in IndexedDB before being uploaded to ElevenLabs.
+- **Audio Upload**: Upload existing audio files (WAV, MP3, M4A up to 25 MB) for voice cloning.
+- **Voice Recording**: Record voice samples directly in the browser using pre-defined sentence prompts.
+- **ElevenLabs Integration**: Submits samples to the ElevenLabs Instant Voice Cloning API.
+- **Local Storage**: Voice samples are stored locally in IndexedDB, then sent directly to ElevenLabs at clone time. Local samples are cleaned up after a successful clone.
+- **Merged sources**: Both uploaded files and recorded samples are always sent together — more data → better clone quality.
+
+## Architecture
+
+All state is hoisted into a single `CloningProvider` that creates one shared `AudioService` instance (one IndexedDB connection, one set of mount-effects). Child hooks receive the shared storage via props.
+
+```
+CloningProvider
+  ├── VoiceStorageContext  (single AudioService / IndexedDB)
+  ├── UploadContext        (useUploadLogic)
+  └── RecordingContext     (useRecording → MediaRecorderManager)
+```
+
+`MediaRecorderManager` (`lib/media-recorder-manager.ts`) is a plain TS class — no React — that holds a `Map<id, {recorder, stream}>`. It stops individual recordings by ID, and calls `stopAll()` on unmount via `useEffect` cleanup, releasing the microphone correctly on navigation.
+
+`useAudioPlayback` owns the `URL.createObjectURL` / `URL.revokeObjectURL` lifecycle. All blob URLs are revoked on `ended`, `error`, or `stopPlaying`.
 
 ## Components
 
-- `VoiceCloneForm`: The main form for voice cloning, integrating upload and recording sections.
-- `RecordingSection`: Component for recording voice samples.
-- `UploadSection`: Component for uploading audio files.
+- `VoiceCloneForm`: Main form — tabs for upload vs. record, voice details, submit.
+- `RecordingSection`: Carousel of 10 sample sentences with record/stop/play/delete per sample.
+- `UploadSection`: Drag-and-drop / file picker for audio uploads.
+- `CloningProvider`: Context provider — wrap any usage of the above components.
 
 ## Hooks
 
-### Core Hooks
+- `useRecording` — composes `useMediaRecorder`, `useAudioPlayback`, `useRecordingState`.
+- `useUploadLogic` — manages uploaded file list.
+- `useVoiceStorage` — IndexedDB CRUD via `@september/audio/AudioService`.
+- `useMediaRecorder` — wraps `MediaRecorderManager` in React state.
+- `useAudioPlayback` — plays recordings, owns URL lifetime.
+- `useRecordingState` — persists recorded sample IDs.
 
-- `useRecording`: Main hook for recording voice samples (composes smaller hooks).
-- `useUpload`: Manage audio file uploads for cloning.
-- `useVoiceStorage`: Manage voice samples in local storage.
+## Utilities
 
-### Specialized Hooks
-
-- `useMediaRecorder`: Low-level MediaRecorder API wrapper.
-- `useAudioPlayback`: Manage playback of recorded samples.
-- `useRecordingState`: Manage the state of multiple recording samples.
+- `collectSampleIds(uploadedFiles, recordings)` — merges both sources, de-duplicates.
+- `MediaRecorderManager` — testable plain-TS class for recorder lifecycle. Mic is exclusive: starting a new recording stops all active ones first. `stopAll()` is called on unmount to release the microphone.
+- `ElevenLabsVoiceClone` — fetch wrapper for `/v1/voices/add` (clone) and `/v1/voices/similar` (similarity search).
 
 ## Usage
 
-### Recording Voice Samples
-
 ```tsx
-import { RecordingProvider, useRecordingContext } from '@september/cloning';
+import { CloningProvider, VoiceCloneForm } from '@september/cloning';
 
-function Recorder() {
-  const { startRecording, stopRecording, status } = useRecordingContext();
-
+export default function ClonePage() {
   return (
-    <div>
-      <p>Status: {status}</p>
-      <button onClick={startRecording}>Start</button>
-      <button onClick={stopRecording}>Stop</button>
-    </div>
+    <CloningProvider>
+      <VoiceCloneForm />
+    </CloningProvider>
   );
 }
 ```

--- a/packages/cloning/components/cloning-provider.tsx
+++ b/packages/cloning/components/cloning-provider.tsx
@@ -1,55 +1,60 @@
 'use client';
 
-import { createContext, useContext } from 'react';
+import { createContext, useContext, useMemo } from 'react';
 
 import { useRecording } from '@september/cloning/hooks/use-recording';
 import { useUploadLogic } from '@september/cloning/hooks/use-upload';
+import { useVoiceStorage, UseVoiceStorageReturn } from '@september/cloning/hooks/use-voice-storage';
 import { RecordingContextType, UploadContextType } from '@september/cloning/types';
+
+// ─── VoiceStorage context (single instance for the whole cloning tree) ───────
+// Hoisted here so useUploadLogic, useRecordingState, and form.tsx all share one
+// AudioService instance and one set of IndexedDB mount-effects.
+
+export const VoiceStorageContext = createContext<UseVoiceStorageReturn | null>(null);
+
+export function useVoiceStorageContext(): UseVoiceStorageReturn {
+  const context = useContext(VoiceStorageContext);
+  if (!context) throw new Error('useVoiceStorageContext must be used within a CloningProvider');
+  return context;
+}
+
+// ─── Upload context ───────────────────────────────────────────────
 
 export const UploadContext = createContext<UploadContextType | null>(null);
 
-export function UploadProvider({
-  children,
-  initialUploadedFiles = [],
-}: {
-  children: React.ReactNode;
-  initialUploadedFiles?: string[];
-}) {
-  const uploadLogic = useUploadLogic(initialUploadedFiles);
-
-  return <UploadContext.Provider value={uploadLogic}>{children}</UploadContext.Provider>;
-}
-
 export function useUpload() {
   const context = useContext(UploadContext);
-  if (!context) throw new Error('useUpload must be used within a UploadProvider');
+  if (!context) throw new Error('useUpload must be used within a CloningProvider');
   return context;
 }
+
+// ─── Recording context ────────────────────────────────────────────
 
 export const RecordingContext = createContext<RecordingContextType | null>(null);
 
-export function RecordingProvider({
-  children,
-  initialRecordings = {},
-}: {
-  children: React.ReactNode;
-  initialRecordings?: Record<string, string>;
-}) {
-  const recordingLogic = useRecording(initialRecordings);
-
-  return <RecordingContext.Provider value={recordingLogic}>{children}</RecordingContext.Provider>;
-}
-
 export function useRecordingContext() {
   const context = useContext(RecordingContext);
-  if (!context) throw new Error('useRecordingContext must be used within a RecordingProvider');
+  if (!context) throw new Error('useRecordingContext must be used within a CloningProvider');
   return context;
 }
 
+// ─── Composite provider ───────────────────────────────────────────
+
 export function CloningProvider({ children }: { children: React.ReactNode }) {
+  // Single shared useVoiceStorage instance — avoids 4 separate AudioService
+  // allocations and 4 IndexedDB mount-scans across the cloning subtree.
+  const voiceStorage = useVoiceStorage();
+  const uploadLogic = useUploadLogic(voiceStorage);
+  const recordingLogic = useRecording({}, voiceStorage);
+
   return (
-    <UploadProvider>
-      <RecordingProvider>{children}</RecordingProvider>
-    </UploadProvider>
+    <VoiceStorageContext.Provider value={voiceStorage}>
+      <UploadContext.Provider value={uploadLogic}>
+        <RecordingContext.Provider value={recordingLogic}>
+          {children}
+        </RecordingContext.Provider>
+      </UploadContext.Provider>
+    </VoiceStorageContext.Provider>
   );
 }

--- a/packages/cloning/components/form.tsx
+++ b/packages/cloning/components/form.tsx
@@ -3,7 +3,6 @@
 import { useMemo, useState } from 'react';
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Search } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import { z } from 'zod';
@@ -14,10 +13,14 @@ import { FormField, FormTextarea } from '@september/ui/components/form';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@september/ui/components/tabs';
 
 import { useAccountContext } from '@september/account';
-import { useRecordingContext, useUpload } from '@september/cloning/components/cloning-provider';
+import {
+  useRecordingContext,
+  useUpload,
+  useVoiceStorageContext,
+} from '@september/cloning/components/cloning-provider';
 import { RecordingSection } from '@september/cloning/components/record';
 import { UploadSection } from '@september/cloning/components/upload';
-import { useVoiceStorage } from '@september/cloning/hooks/use-voice-storage';
+import { collectSampleIds } from '@september/cloning/lib/collect-sample-ids';
 import { ElevenLabsVoiceClone } from '@september/cloning/lib/elevenlabs-clone';
 
 const CloneVoiceSchema = z.object({
@@ -33,20 +36,17 @@ export function VoiceCloneForm() {
   const { account } = useAccountContext();
   const { recordings } = useRecordingContext();
   const { uploadedFiles } = useUpload();
-  const { downloadVoiceSample } = useVoiceStorage();
+  const { downloadVoiceSample, deleteVoiceSample } = useVoiceStorageContext();
 
   const form = useForm<CloneVoiceFormData>({
     resolver: zodResolver(CloneVoiceSchema),
-    defaultValues: {
-      name: '',
-      description: '',
-    },
+    defaultValues: { name: '', description: '' },
   });
 
-  // Get ElevenLabs API key from account
-  const elevenlabsApiKey = useMemo(() => {
-    return account?.ai_providers?.elevenlabs?.api_key;
-  }, [account]);
+  const elevenlabsApiKey = useMemo(
+    () => account?.ai_providers?.elevenlabs?.api_key,
+    [account]
+  );
 
   const handleSubmit = async (data: CloneVoiceFormData) => {
     if (!elevenlabsApiKey) {
@@ -54,8 +54,8 @@ export function VoiceCloneForm() {
       return;
     }
 
-    // Get all audio files (uploads or recordings)
-    const fileIds = uploadedFiles.length > 0 ? uploadedFiles : Object.values(recordings);
+    // Merge uploads AND recordings — ElevenLabs produces better clones with more data
+    const fileIds = collectSampleIds(uploadedFiles, recordings);
 
     if (fileIds.length === 0) {
       toast.error('Please upload or record at least one audio sample.');
@@ -65,18 +65,16 @@ export function VoiceCloneForm() {
     setIsSubmitting(true);
 
     try {
-      // Download all files from local storage and convert to File objects
-      const files: File[] = [];
-      for (const id of fileIds) {
-        const blob = await downloadVoiceSample(id);
-        // Extract filename from ID or use a default
-        const parts = id.split('/');
-        const filename = parts[parts.length - 1] || `sample-${id}.webm`;
-        const file = new File([blob], filename, { type: blob.type || 'audio/webm' });
-        files.push(file);
-      }
+      // Download all samples in parallel from IndexedDB
+      const files = await Promise.all(
+        fileIds.map(async id => {
+          const blob = await downloadVoiceSample(id);
+          const parts = id.split('/');
+          const filename = parts[parts.length - 1] || `sample-${id}.webm`;
+          return new File([blob], filename, { type: blob.type || 'audio/webm' });
+        })
+      );
 
-      // Create voice clone
       const cloneService = new ElevenLabsVoiceClone(elevenlabsApiKey);
       const result = await cloneService.cloneVoice({
         files,
@@ -85,10 +83,12 @@ export function VoiceCloneForm() {
       });
 
       toast.success('Voice Clone Created', {
-        description: `Successfully created voice "${result.name}" with ID: ${result.voice_id}`,
+        description: `Successfully created voice "${result.name}" (ID: ${result.voice_id})`,
       });
 
-      // Reset form
+      // Clean up local samples — already sent to ElevenLabs, no longer needed
+      await Promise.allSettled(fileIds.map(id => deleteVoiceSample(id)));
+
       form.reset();
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : 'Failed to create voice clone';
@@ -104,7 +104,6 @@ export function VoiceCloneForm() {
 
   return (
     <div className="space-y-6 pb-24 max-w-2xl">
-      {/* API Key Warning */}
       {!hasApiKey && (
         <Card className="border-amber-200 bg-amber-50">
           <CardContent className="pt-6">
@@ -120,7 +119,6 @@ export function VoiceCloneForm() {
       )}
 
       <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-6">
-        {/* Upload and Record Tabs */}
         <Card>
           <CardHeader>
             <CardTitle>Voice Samples</CardTitle>
@@ -144,7 +142,6 @@ export function VoiceCloneForm() {
           </CardContent>
         </Card>
 
-        {/* Voice Details */}
         <Card>
           <CardHeader>
             <CardTitle>Voice Details</CardTitle>
@@ -169,7 +166,6 @@ export function VoiceCloneForm() {
               rows={3}
             />
 
-            {/* Submit Button */}
             <div className="pt-4 border-t">
               <Button
                 type="submit"
@@ -187,26 +183,6 @@ export function VoiceCloneForm() {
             </div>
           </CardContent>
         </Card>
-
-        {/* Find Similar Voices */}
-        {hasSamples && (
-          <Card>
-            <CardHeader>
-              <CardTitle>Find Similar Voices</CardTitle>
-              <CardDescription>
-                Not satisfied with the cloned voice? Try searching for similar voices using the
-                samples you uploaded or recorded.
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <Button variant="outline" type="button" asChild>
-                <a href="/app/voices?search=similar">
-                  <Search className="mr-2 h-4 w-4" /> Search for Similar Voices
-                </a>
-              </Button>
-            </CardContent>
-          </Card>
-        )}
       </form>
     </div>
   );

--- a/packages/cloning/hooks/use-audio-playback.ts
+++ b/packages/cloning/hooks/use-audio-playback.ts
@@ -5,7 +5,7 @@ import { useCallback, useRef, useState } from 'react';
 import type { RecordingStatus } from '@september/cloning/types';
 
 interface UseAudioPlaybackReturn {
-  playRecording: (id: string, audioUrl: string) => Promise<void>;
+  playRecording: (id: string, blob: Blob) => Promise<void>;
   stopPlaying: (id: string) => void;
   playbackStatus: Record<string, RecordingStatus>;
   playbackError: Record<string, string | null>;
@@ -15,7 +15,8 @@ export function useAudioPlayback(): UseAudioPlaybackReturn {
   const [playbackStatus, setPlaybackStatus] = useState<Record<string, RecordingStatus>>({});
   const [playbackError, setPlaybackError] = useState<Record<string, string | null>>({});
 
-  const audioRefs = useRef<Record<string, HTMLAudioElement>>({});
+  // Track {audio, objectUrl} per sample so we can revoke and clean up properly
+  const audioRefs = useRef<Record<string, { audio: HTMLAudioElement; url: string }>>({});
 
   const setStatusFor = useCallback((id: string, status: RecordingStatus) => {
     setPlaybackStatus(prev => ({ ...prev, [id]: status }));
@@ -25,23 +26,43 @@ export function useAudioPlayback(): UseAudioPlaybackReturn {
     setPlaybackError(prev => ({ ...prev, [id]: error }));
   }, []);
 
+  const revokeAndClean = useCallback((id: string) => {
+    const entry = audioRefs.current[id];
+    if (entry) {
+      URL.revokeObjectURL(entry.url);
+      delete audioRefs.current[id];
+    }
+  }, []);
+
   const playRecording = useCallback(
-    async (id: string, audioUrl: string) => {
-      // Stop all other playing audio
-      Object.values(audioRefs.current).forEach(audio => {
-        audio.pause();
-        audio.currentTime = 0;
-      });
+    async (id: string, blob: Blob) => {
+      // Stop all other playing audio first
+      for (const [otherId, entry] of Object.entries(audioRefs.current)) {
+        entry.audio.pause();
+        entry.audio.currentTime = 0;
+        if (otherId !== id) {
+          URL.revokeObjectURL(entry.url);
+          delete audioRefs.current[otherId];
+          setStatusFor(otherId, 'idle');
+        }
+      }
+
+      // Revoke any previous URL for this id
+      revokeAndClean(id);
+
+      const url = URL.createObjectURL(blob);
 
       try {
-        const audio = new Audio(audioUrl);
-        audioRefs.current[id] = audio;
+        const audio = new Audio(url);
+        audioRefs.current[id] = { audio, url };
 
         audio.onended = () => {
+          revokeAndClean(id);
           setStatusFor(id, 'idle');
         };
 
         audio.onerror = () => {
+          revokeAndClean(id);
           setStatusFor(id, 'error');
           setErrorFor(id, 'Failed to play recording');
         };
@@ -49,21 +70,26 @@ export function useAudioPlayback(): UseAudioPlaybackReturn {
         await audio.play();
         setStatusFor(id, 'playing');
       } catch (err) {
+        revokeAndClean(id);
         setStatusFor(id, 'error');
         setErrorFor(id, err instanceof Error ? err.message : 'Failed to play recording');
       }
     },
-    [setStatusFor, setErrorFor]
+    [setStatusFor, setErrorFor, revokeAndClean]
   );
 
-  const stopPlaying = useCallback((id: string) => {
-    const audio = audioRefs.current[id];
-    if (!audio) return;
+  const stopPlaying = useCallback(
+    (id: string) => {
+      const entry = audioRefs.current[id];
+      if (!entry) return;
 
-    audio.pause();
-    audio.currentTime = 0;
-    setStatusFor(id, 'idle');
-  }, [setStatusFor]);
+      entry.audio.pause();
+      entry.audio.currentTime = 0;
+      revokeAndClean(id);
+      setStatusFor(id, 'idle');
+    },
+    [setStatusFor, revokeAndClean]
+  );
 
   return {
     playRecording,

--- a/packages/cloning/hooks/use-media-recorder.test.ts
+++ b/packages/cloning/hooks/use-media-recorder.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Regression tests for MediaRecorderManager (the logic layer under useMediaRecorder).
+ *
+ * REGRESSION 1: stopRecording(id) previously ignored the id — a single mediaRecorderRef
+ *   was shared. Starting recording B before stopping A left stream A's tracks open,
+ *   keeping the microphone indicator lit.
+ *
+ * REGRESSION 2: No unmount cleanup. Navigating away while recording left the
+ *   microphone track open until the tab closed.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MediaRecorderManager } from '../lib/media-recorder-manager';
+
+// ─────────────────────────────────────────────────────────────────
+// Stubs
+// ─────────────────────────────────────────────────────────────────
+interface FakeTrack { stop: ReturnType<typeof vi.fn> }
+interface FakeStream { getTracks: () => FakeTrack[]; id: string }
+
+const makeTrack = (): FakeTrack => ({ stop: vi.fn() });
+const makeStream = (id: string): FakeStream => {
+  // Memoize so every getTracks() call returns the same track instances.
+  // Without this, each call creates fresh spies and stop() is never seen.
+  const tracks = [makeTrack(), makeTrack()];
+  return { id, getTracks: () => tracks };
+};
+
+let streamCounter = 0;
+const streamInstances: FakeStream[] = [];
+
+class FakeMediaRecorder {
+  static isTypeSupported = () => true;
+  ondataavailable: ((e: { data: { size: number } }) => void) | null = null;
+  onstop: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  state = 'inactive';
+  streamId: string;
+  private _stopCb: (() => void) | null = null;
+
+  start = vi.fn(() => { this.state = 'recording'; });
+  stop = vi.fn(() => {
+    if (this.state === 'inactive') return;
+    this.state = 'inactive';
+    this.onstop?.();
+  });
+
+  constructor(stream: FakeStream) {
+    this.streamId = stream.id;
+  }
+}
+
+beforeEach(() => {
+  streamCounter = 0;
+  streamInstances.length = 0;
+
+  vi.stubGlobal('navigator', {
+    mediaDevices: {
+      getUserMedia: vi.fn(async () => {
+        const s = makeStream(`stream-${streamCounter++}`);
+        streamInstances.push(s);
+        return s as unknown as MediaStream;
+      }),
+    },
+  });
+
+  vi.stubGlobal('MediaRecorder', FakeMediaRecorder);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('MediaRecorderManager', () => {
+  it('[REGRESSION] starting recording B before stopping A stops stream A tracks', async () => {
+    const mgr = new MediaRecorderManager();
+
+    await mgr.startRecording('sample-a');
+    const streamA = streamInstances[0];
+    const trackA = streamA.getTracks()[0] as FakeTrack;
+
+    // Start B without stopping A first
+    await mgr.startRecording('sample-b');
+
+    // Stream A's tracks must now be stopped
+    expect(trackA.stop).toHaveBeenCalled();
+  });
+
+  it('[REGRESSION] stopAll() stops all active recording tracks (simulates unmount)', async () => {
+    const mgr = new MediaRecorderManager();
+    await mgr.startRecording('sample-x');
+    const tracks = streamInstances[0].getTracks() as FakeTrack[];
+
+    mgr.stopAll();
+
+    tracks.forEach(t => expect(t.stop).toHaveBeenCalled());
+  });
+
+  it('stopRecording(id) targets the specific recording by id', async () => {
+    const mgr = new MediaRecorderManager();
+    await mgr.startRecording('sample-a');
+    await mgr.startRecording('sample-b');
+
+    const tracksA = streamInstances[0].getTracks() as FakeTrack[];
+    const tracksB = streamInstances[1].getTracks() as FakeTrack[];
+
+    // Stop only A — but starting B already stopped A's stream in this impl
+    // (mic is exclusive). This verifies the Map-keyed approach and that
+    // stopRecording('b') targets the right entry.
+    mgr.stopRecording('sample-b');
+    tracksB.forEach(t => expect(t.stop).toHaveBeenCalled());
+    // A's tracks were already stopped when B started
+    tracksA.forEach(t => expect(t.stop).toHaveBeenCalled());
+  });
+
+  it('calls onComplete callback with the blob when recording stops', async () => {
+    const onComplete = vi.fn();
+    const mgr = new MediaRecorderManager();
+    mgr.setCallbacks({ onComplete });
+
+    await mgr.startRecording('s1');
+    mgr.stopRecording('s1');
+
+    expect(onComplete).toHaveBeenCalledWith('s1', expect.any(Blob));
+  });
+
+  it('calls onStatusChange("recording") on start and clean stop', async () => {
+    const statusChanges: Array<[string, string]> = [];
+    const mgr = new MediaRecorderManager();
+    mgr.setCallbacks({ onStatusChange: (id, s) => statusChanges.push([id, s]) });
+
+    await mgr.startRecording('s1');
+    expect(statusChanges).toContainEqual(['s1', 'recording']);
+  });
+
+  it('sets status to error and calls onError when getUserMedia is denied', async () => {
+    vi.mocked(navigator.mediaDevices.getUserMedia).mockRejectedValueOnce(
+      new Error('Permission denied')
+    );
+
+    const errors: Array<[string, string]> = [];
+    const statuses: Array<[string, string]> = [];
+    const mgr = new MediaRecorderManager();
+    mgr.setCallbacks({
+      onError: (id, msg) => errors.push([id, msg]),
+      onStatusChange: (id, s) => statuses.push([id, s]),
+    });
+
+    await mgr.startRecording('s1');
+
+    expect(statuses).toContainEqual(['s1', 'error']);
+    expect(errors[0][1]).toContain('Permission denied');
+  });
+});

--- a/packages/cloning/hooks/use-media-recorder.ts
+++ b/packages/cloning/hooks/use-media-recorder.ts
@@ -1,7 +1,8 @@
 'use client';
 
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
+import { MediaRecorderManager } from '@september/cloning/lib/media-recorder-manager';
 import type { RecordingStatus } from '@september/cloning/types';
 
 interface UseMediaRecorderReturn {
@@ -16,62 +17,38 @@ export function useMediaRecorder(): UseMediaRecorderReturn {
   const [recordingStatus, setRecordingStatus] = useState<Record<string, RecordingStatus>>({});
   const [recordingError, setRecordingError] = useState<Record<string, string | null>>({});
 
-  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
-  const streamRef = useRef<MediaStream | null>(null);
-  const recordingCompleteCallbackRef = useRef<((id: string, blob: Blob) => void) | null>(null);
+  const managerRef = useRef<MediaRecorderManager | null>(null);
+  const completeCallbackRef = useRef<((id: string, blob: Blob) => void) | null>(null);
 
-  const setStatusFor = useCallback((id: string, status: RecordingStatus) => {
-    setRecordingStatus(prev => ({ ...prev, [id]: status }));
+  if (!managerRef.current) {
+    managerRef.current = new MediaRecorderManager();
+  }
+
+  managerRef.current.setCallbacks({
+    onComplete: (id, blob) => completeCallbackRef.current?.(id, blob),
+    onStatusChange: (id, status) =>
+      setRecordingStatus(prev => ({ ...prev, [id]: status as RecordingStatus })),
+    onError: (id, error) =>
+      setRecordingError(prev => ({ ...prev, [id]: error })),
+  });
+
+  // Release the microphone when the component unmounts
+  useEffect(() => {
+    return () => {
+      managerRef.current?.stopAll();
+    };
   }, []);
 
-  const setErrorFor = useCallback((id: string, error: string | null) => {
-    setRecordingError(prev => ({ ...prev, [id]: error }));
+  const startRecording = useCallback(async (id: string) => {
+    await managerRef.current?.startRecording(id);
   }, []);
-
-  const startRecording = useCallback(
-    async (id: string) => {
-      setStatusFor(id, 'recording');
-      setErrorFor(id, null);
-
-      try {
-        const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-        streamRef.current = stream;
-        const mediaRecorder = new MediaRecorder(stream);
-        const chunks: BlobPart[] = [];
-
-        mediaRecorder.ondataavailable = event => {
-          chunks.push(event.data);
-        };
-
-        mediaRecorder.onstop = () => {
-          const blob = new Blob(chunks, { type: 'audio/webm' });
-          recordingCompleteCallbackRef.current?.(id, blob);
-
-          if (streamRef.current) {
-            streamRef.current.getTracks().forEach(track => track.stop());
-            streamRef.current = null;
-          }
-        };
-
-        mediaRecorderRef.current = mediaRecorder;
-        mediaRecorder.start();
-      } catch (err) {
-        setStatusFor(id, 'error');
-        setErrorFor(id, err instanceof Error ? err.message : 'Failed to start recording');
-      }
-    },
-    [setStatusFor, setErrorFor]
-  );
 
   const stopRecording = useCallback((id: string) => {
-    if (mediaRecorderRef.current) {
-      mediaRecorderRef.current.stop();
-      mediaRecorderRef.current = null;
-    }
+    managerRef.current?.stopRecording(id);
   }, []);
 
   const onRecordingComplete = useCallback((callback: (id: string, blob: Blob) => void) => {
-    recordingCompleteCallbackRef.current = callback;
+    completeCallbackRef.current = callback;
   }, []);
 
   return {

--- a/packages/cloning/hooks/use-recording-state.ts
+++ b/packages/cloning/hooks/use-recording-state.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 
-import { useVoiceStorage } from '@september/cloning/hooks/use-voice-storage';
+import { useVoiceStorage, UseVoiceStorageReturn } from '@september/cloning/hooks/use-voice-storage';
 
 interface UseRecordingStateReturn {
   recordings: Record<string, string>;
@@ -12,60 +12,44 @@ interface UseRecordingStateReturn {
 }
 
 export function useRecordingState(
-  initialRecordings: Record<string, string> = {}
+  initialRecordings: Record<string, string> = {},
+  sharedStorage?: UseVoiceStorageReturn
 ): UseRecordingStateReturn {
   const [recordings, setRecordings] = useState<Record<string, string>>(initialRecordings);
-  const { uploadVoiceSample, deleteVoiceSample, getVoiceSamples } = useVoiceStorage();
+  const ownStorage = useVoiceStorage();
+  const { uploadVoiceSample, deleteVoiceSample, getVoiceSamples } =
+    sharedStorage ?? ownStorage;
 
-  // Load recordings on mount
   useEffect(() => {
-    const loadRecordings = async () => {
-      try {
-        const samples = await getVoiceSamples('recording');
-        const recordingsMap: Record<string, string> = {};
+    getVoiceSamples('recording')
+      .then(samples => {
+        const map: Record<string, string> = {};
         samples.forEach(sample => {
-          if (sample.sample_id) {
-            recordingsMap[sample.sample_id] = sample.id;
-          }
+          if (sample.sample_id) map[sample.sample_id] = sample.id;
         });
-        setRecordings(recordingsMap);
-      } catch (err) {
-        console.error('Error loading recordings:', err);
-      }
-    };
-    loadRecordings();
+        setRecordings(map);
+      })
+      .catch(err => console.error('Error loading recordings:', err));
   }, [getVoiceSamples]);
 
   const saveRecording = useCallback(
     async (id: string, blob: Blob) => {
-      try {
-        const file = new File([blob], `${id}.webm`, { type: 'audio/webm' });
-        const sampleId = await uploadVoiceSample({ file, type: 'recording', sampleId: id });
-        setRecordings(prev => ({ ...prev, [id]: sampleId }));
-      } catch (err) {
-        console.error('Error saving recording:', err);
-        throw err;
-      }
+      const file = new File([blob], `${id}.webm`, { type: 'audio/webm' });
+      const sampleId = await uploadVoiceSample({ file, type: 'recording', sampleId: id });
+      setRecordings(prev => ({ ...prev, [id]: sampleId }));
     },
     [uploadVoiceSample]
   );
 
   const deleteRecording = useCallback(
     async (id: string) => {
-      try {
-        const sampleId = recordings[id];
-        if (sampleId) {
-          await deleteVoiceSample(sampleId);
-        }
-        setRecordings(prev => {
-          const next = { ...prev };
-          delete next[id];
-          return next;
-        });
-      } catch (err) {
-        console.error('Error deleting recording:', err);
-        throw err;
-      }
+      const sampleId = recordings[id];
+      if (sampleId) await deleteVoiceSample(sampleId);
+      setRecordings(prev => {
+        const next = { ...prev };
+        delete next[id];
+        return next;
+      });
     },
     [recordings, deleteVoiceSample]
   );

--- a/packages/cloning/hooks/use-recording.ts
+++ b/packages/cloning/hooks/use-recording.ts
@@ -1,13 +1,13 @@
 'use client';
 
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect } from 'react';
 
 import { toast } from 'sonner';
 
 import { useMediaRecorder } from '@september/cloning/hooks/use-media-recorder';
 import { useAudioPlayback } from '@september/cloning/hooks/use-audio-playback';
 import { useRecordingState } from '@september/cloning/hooks/use-recording-state';
-import { useVoiceStorage } from '@september/cloning/hooks/use-voice-storage';
+import { useVoiceStorage, UseVoiceStorageReturn } from '@september/cloning/hooks/use-voice-storage';
 import { RecordingStatus } from '../types';
 
 export interface UseRecordingReturn {
@@ -21,30 +21,28 @@ export interface UseRecordingReturn {
   errors: Record<string, string | null>;
 }
 
-export function useRecording(initialRecordings: Record<string, string> = {}): UseRecordingReturn {
-  const [internalErrors, setInternalErrors] = useState<Record<string, string | null>>({});
+export function useRecording(
+  initialRecordings: Record<string, string> = {},
+  sharedStorage?: UseVoiceStorageReturn
+): UseRecordingReturn {
   const mediaRecorder = useMediaRecorder();
   const audioPlayback = useAudioPlayback();
-  const recordingState = useRecordingState(initialRecordings);
-  const { downloadVoiceSample } = useVoiceStorage();
+  const recordingState = useRecordingState(initialRecordings, sharedStorage);
+  const ownStorage = useVoiceStorage();
+  const { downloadVoiceSample } = sharedStorage ?? ownStorage;
 
-  // Connect recording completion to state save
-  const handleRecordingComplete = useCallback(
-    async (id: string, blob: Blob) => {
+  // Register the completion handler in useEffect — not during render
+  useEffect(() => {
+    mediaRecorder.onRecordingComplete(async (id: string, blob: Blob) => {
       try {
         await recordingState.saveRecording(id, blob);
-        setInternalErrors(prev => ({ ...prev, [id]: null }));
         toast.success('Recording saved');
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Failed to save recording';
-        setInternalErrors(prev => ({ ...prev, [id]: message }));
         toast.error(message);
       }
-    },
-    [recordingState]
-  );
-
-  mediaRecorder.onRecordingComplete(handleRecordingComplete);
+    });
+  }, [mediaRecorder, recordingState]);
 
   const playRecording = useCallback(
     async (id: string) => {
@@ -53,15 +51,8 @@ export function useRecording(initialRecordings: Record<string, string> = {}): Us
         if (!sampleId) return;
 
         const blob = await downloadVoiceSample(sampleId);
-        const url = URL.createObjectURL(blob);
-
-        await audioPlayback.playRecording(id, url);
-
-        // Clean up URL after playback completes or errors
-        const audio = new Audio(url);
-        const cleanup = () => URL.revokeObjectURL(url);
-        audio.addEventListener('ended', cleanup);
-        audio.addEventListener('error', cleanup);
+        // Pass Blob directly — useAudioPlayback owns URL creation and revocation
+        await audioPlayback.playRecording(id, blob);
       } catch (err) {
         console.error('Error playing recording:', err);
         toast.error('Failed to play recording');
@@ -72,13 +63,11 @@ export function useRecording(initialRecordings: Record<string, string> = {}): Us
 
   const deleteRecording = useCallback(
     async (id: string) => {
-      setInternalErrors(prev => ({ ...prev, [id]: null }));
       try {
         await recordingState.deleteRecording(id);
         toast.success('Recording deleted');
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Failed to delete recording';
-        setInternalErrors(prev => ({ ...prev, [id]: message }));
         toast.error(message);
         throw err;
       }
@@ -86,7 +75,6 @@ export function useRecording(initialRecordings: Record<string, string> = {}): Us
     [recordingState]
   );
 
-  // Combine status and errors from all hooks
   const status = {
     ...mediaRecorder.recordingStatus,
     ...audioPlayback.playbackStatus,
@@ -95,7 +83,6 @@ export function useRecording(initialRecordings: Record<string, string> = {}): Us
   const errors = {
     ...mediaRecorder.recordingError,
     ...audioPlayback.playbackError,
-    ...internalErrors,
   };
 
   return {

--- a/packages/cloning/hooks/use-upload.ts
+++ b/packages/cloning/hooks/use-upload.ts
@@ -2,25 +2,27 @@
 
 import { useCallback, useEffect, useState } from 'react';
 
-import { useVoiceStorage } from '@september/cloning/hooks/use-voice-storage';
+import { useVoiceStorage, UseVoiceStorageReturn } from '@september/cloning/hooks/use-voice-storage';
 import { UploadStatus } from '@september/cloning/types';
 
-export function useUploadLogic(initialUploadedFiles: string[] = []) {
+/**
+ * When called from CloningProvider, receives the shared voiceStorage so there
+ * is one AudioService instance and one IndexedDB mount-scan across the tree.
+ * When called standalone, creates its own storage instance.
+ */
+export function useUploadLogic(sharedStorage?: UseVoiceStorageReturn) {
+  const ownStorage = useVoiceStorage();
+  const { uploadVoiceSample, deleteVoiceSample, getVoiceSamples } =
+    sharedStorage ?? ownStorage;
+
   const [status, setStatus] = useState<UploadStatus>('idle');
   const [error, setError] = useState<string | null>(null);
-  const [uploadedFiles, setUploadedFiles] = useState<string[]>(initialUploadedFiles);
-  const { uploadVoiceSample, deleteVoiceSample, getVoiceSamples } = useVoiceStorage();
+  const [uploadedFiles, setUploadedFiles] = useState<string[]>([]);
 
   useEffect(() => {
-    const loadFiles = async () => {
-      try {
-        const samples = await getVoiceSamples('upload');
-        setUploadedFiles(samples.map(s => s.id));
-      } catch (err) {
-        console.error('Error loading uploaded files:', err);
-      }
-    };
-    loadFiles();
+    getVoiceSamples('upload')
+      .then(samples => setUploadedFiles(samples.map(s => s.id)))
+      .catch(err => console.error('Error loading uploaded files:', err));
   }, [getVoiceSamples]);
 
   const uploadFile = useCallback(

--- a/packages/cloning/hooks/use-voice-storage.ts
+++ b/packages/cloning/hooks/use-voice-storage.ts
@@ -2,8 +2,6 @@
 
 import { useCallback, useMemo } from 'react';
 
-import { toast } from 'sonner';
-
 import { useAuth } from '@september/account';
 import { AudioService } from '@september/audio';
 import { VoiceSample } from '../types';
@@ -36,96 +34,73 @@ export function useVoiceStorage(): UseVoiceStorageReturn {
       type: 'upload' | 'recording';
       sampleId?: string;
     }) => {
-      try {
-        // Convert file to base64 for AudioService
-        const arrayBuffer = await file.arrayBuffer();
-        const base64 = btoa(String.fromCharCode(...new Uint8Array(arrayBuffer)));
-        const mimeType = file.type || 'audio/webm';
+      const contentType = file.type || 'audio/webm';
+      const filename =
+        type === 'recording' && sampleId
+          ? `${sampleId}.webm`
+          : `${Date.now()}-${file.name}`;
 
-        // Generate path
-        const filename =
-          type === 'recording' && sampleId
-            ? `${sampleId}.webm`
-            : `${Date.now()}-${file.name}`;
-        
-        const path = `voice-samples/${userId}/${type}/${filename}`;
+      const path = `voice-samples/${userId}/${type}/${filename}`;
 
-        // Store via AudioService
-        await audioService.uploadAudio({
-          path,
-          blob: base64,
-          contentType: mimeType,
-          metadata: {
-            user_id: userId,
-            type,
-            sample_id: sampleId,
-            file_name: type === 'upload' ? file.name : undefined,
-          },
-        });
+      // Binary upload — avoids the base64 call-stack overflow on large files.
+      await audioService.uploadAudioBinary({
+        path,
+        blob: file,
+        contentType,
+        metadata: {
+          user_id: userId,
+          type,
+          sample_id: sampleId,
+          file_name: type === 'upload' ? file.name : undefined,
+        },
+      });
 
-        toast.success('Voice sample uploaded');
-        return path;
-      } catch (err) {
-        console.error('Failed to upload voice sample:', err);
-        toast.error('Failed to upload voice sample');
-        throw err;
-      }
+      return path;
     },
     [userId, audioService]
   );
 
   const getVoiceSamples = useCallback(
     async (type?: 'upload' | 'recording'): Promise<VoiceSample[]> => {
-      try {
-        if (!type) {
-          // If no type, we'd need to list both folders.
-          // For now, let's assume type is always provided as per current usage.
-          const uploads = await getVoiceSamples('upload');
-          const recordings = await getVoiceSamples('recording');
-          return [...uploads, ...recordings];
-        }
-
-        const folderPath = `voice-samples/${userId}/${type}`;
-        const files = await audioService.listAudio(folderPath);
-
-        return (files || []).map(file => {
-          const metadata = file.metadata || {};
-          return {
-            id: `${folderPath}/${file.name}`,
-            user_id: (metadata.user_id as string) || userId,
-            type: (metadata.type as 'upload' | 'recording') || type,
-            sample_id: metadata.sample_id as string | undefined,
-            file_name: metadata.file_name as string | undefined,
-            created_at: new Date(file.created_at),
-          };
-        });
-      } catch (err) {
-        console.error('Failed to fetch voice samples:', err);
-        throw err;
+      if (!type) {
+        const [uploads, recordings] = await Promise.all([
+          getVoiceSamples('upload'),
+          getVoiceSamples('recording'),
+        ]);
+        return [...uploads, ...recordings];
       }
+
+      const folderPath = `voice-samples/${userId}/${type}`;
+      const files = await audioService.listAudio(folderPath);
+
+      return (files || []).map(file => {
+        const metadata = file.metadata || {};
+        return {
+          id: `${folderPath}/${file.name}`,
+          user_id: (metadata.user_id as string) || userId,
+          type: (metadata.type as 'upload' | 'recording') || type,
+          sample_id: metadata.sample_id as string | undefined,
+          file_name: metadata.file_name as string | undefined,
+          created_at: new Date(file.created_at),
+        };
+      });
     },
     [userId, audioService]
   );
 
-  const deleteVoiceSample = useCallback(async (id: string) => {
-    try {
+  const deleteVoiceSample = useCallback(
+    async (id: string) => {
       await audioService.deleteAudio(id);
-      toast.success('Voice sample deleted');
-    } catch (err) {
-      console.error('Failed to delete voice sample:', err);
-      toast.error('Failed to delete voice sample');
-      throw err;
-    }
-  }, [audioService]);
+    },
+    [audioService]
+  );
 
-  const downloadVoiceSample = useCallback(async (id: string): Promise<Blob> => {
-    try {
-      return await audioService.downloadAudio(id);
-    } catch (err) {
-      console.error('Failed to download voice sample:', err);
-      throw err;
-    }
-  }, [audioService]);
+  const downloadVoiceSample = useCallback(
+    async (id: string): Promise<Blob> => {
+      return audioService.downloadAudio(id);
+    },
+    [audioService]
+  );
 
   return {
     uploadVoiceSample,

--- a/packages/cloning/index.ts
+++ b/packages/cloning/index.ts
@@ -8,5 +8,7 @@ export * from '@september/cloning/components/upload';
 export * from '@september/cloning/components/record';
 export * from '@september/cloning/components/form';
 export * from '@september/cloning/lib/elevenlabs-clone';
+export * from '@september/cloning/lib/collect-sample-ids';
+export * from '@september/cloning/lib/media-recorder-manager';
 export * from '@september/cloning/hooks/use-voice-storage';
 export * from '@september/cloning/types';

--- a/packages/cloning/lib/collect-sample-ids.test.ts
+++ b/packages/cloning/lib/collect-sample-ids.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Regression test for sample collection logic
+ *
+ * REGRESSION: form.tsx used:
+ *   const fileIds = uploadedFiles.length > 0 ? uploadedFiles : Object.values(recordings);
+ *
+ * This silently drops recordings whenever any upload is present, sending fewer
+ * samples to ElevenLabs and producing lower-quality voice clones without any
+ * error or warning.
+ *
+ * The fix extracts this into collectSampleIds() and merges both sources.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { collectSampleIds } from './collect-sample-ids';
+
+describe('collectSampleIds', () => {
+  it('[REGRESSION] includes BOTH uploads and recordings when both are present', () => {
+    const uploadedFiles = ['path/upload/a.mp3', 'path/upload/b.mp3'];
+    const recordings = { 'sample-1': 'path/recording/s1.webm', 'sample-2': 'path/recording/s2.webm' };
+
+    const result = collectSampleIds(uploadedFiles, recordings);
+
+    // Must contain all 4 — not just the 2 uploads
+    expect(result).toHaveLength(4);
+    expect(result).toContain('path/upload/a.mp3');
+    expect(result).toContain('path/upload/b.mp3');
+    expect(result).toContain('path/recording/s1.webm');
+    expect(result).toContain('path/recording/s2.webm');
+  });
+
+  it('returns only uploads when no recordings exist', () => {
+    const result = collectSampleIds(['path/upload/a.mp3'], {});
+    expect(result).toEqual(['path/upload/a.mp3']);
+  });
+
+  it('returns only recordings when no uploads exist', () => {
+    const result = collectSampleIds([], { s1: 'path/recording/s1.webm' });
+    expect(result).toEqual(['path/recording/s1.webm']);
+  });
+
+  it('returns empty array when both are empty', () => {
+    const result = collectSampleIds([], {});
+    expect(result).toEqual([]);
+  });
+
+  it('deduplicates ids that appear in both sources', () => {
+    // Shouldn't happen in practice, but be safe
+    const sharedPath = 'path/shared.webm';
+    const result = collectSampleIds([sharedPath], { s1: sharedPath });
+    expect(result.filter(id => id === sharedPath)).toHaveLength(1);
+  });
+});

--- a/packages/cloning/lib/collect-sample-ids.ts
+++ b/packages/cloning/lib/collect-sample-ids.ts
@@ -1,0 +1,16 @@
+/**
+ * Merge uploaded file IDs and recorded sample IDs into a single de-duplicated list.
+ *
+ * Previously form.tsx used:
+ *   fileIds = uploadedFiles.length > 0 ? uploadedFiles : Object.values(recordings);
+ *
+ * That silently dropped recordings whenever any upload was present. ElevenLabs
+ * accepts multiple samples and produces better clones with more data, so we want all.
+ */
+export function collectSampleIds(
+  uploadedFiles: string[],
+  recordings: Record<string, string>
+): string[] {
+  const all = [...uploadedFiles, ...Object.values(recordings)];
+  return [...new Set(all)];
+}

--- a/packages/cloning/lib/elevenlabs-clone.test.ts
+++ b/packages/cloning/lib/elevenlabs-clone.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Unit + regression tests for ElevenLabsVoiceClone
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ElevenLabsVoiceClone } from './elevenlabs-clone';
+
+const makeFile = (name: string, type = 'audio/webm') =>
+  new File([new Uint8Array(16)], name, { type });
+
+describe('ElevenLabsVoiceClone', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('throws when api key is empty string', async () => {
+    const svc = new ElevenLabsVoiceClone('');
+    await expect(svc.cloneVoice({ files: [makeFile('a.webm')], name: 'Test' })).rejects.toThrow(
+      'ElevenLabs API key is required'
+    );
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('throws when no files are provided', async () => {
+    const svc = new ElevenLabsVoiceClone('key-abc');
+    await expect(svc.cloneVoice({ files: [], name: 'Test' })).rejects.toThrow(
+      'At least one audio file is required'
+    );
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('posts multipart to ElevenLabs and returns voice_id + name', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ voice_id: 'v-123', name: 'My Voice' }),
+    } as Response);
+
+    const svc = new ElevenLabsVoiceClone('key-abc');
+    const result = await svc.cloneVoice({
+      files: [makeFile('a.webm'), makeFile('b.webm')],
+      name: 'My Voice',
+      description: 'Calm tone',
+    });
+
+    expect(result.voice_id).toBe('v-123');
+    expect(result.name).toBe('My Voice');
+    expect(fetch).toHaveBeenCalledOnce();
+
+    const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('/v1/voices/add');
+    expect((init.headers as Record<string, string>)['xi-api-key']).toBe('key-abc');
+    expect(init.body).toBeInstanceOf(FormData);
+
+    const fd = init.body as FormData;
+    expect(fd.get('name')).toBe('My Voice');
+    expect(fd.get('description')).toBe('Calm tone');
+  });
+
+  it('falls back to request name when response omits name', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ voice_id: 'v-456' }),
+    } as Response);
+
+    const svc = new ElevenLabsVoiceClone('key-abc');
+    const result = await svc.cloneVoice({ files: [makeFile('a.webm')], name: 'Fallback' });
+    expect(result.name).toBe('Fallback');
+  });
+
+  it('parses JSON error detail from a non-ok response', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      status: 422,
+      statusText: 'Unprocessable Entity',
+      text: async () => JSON.stringify({ detail: { message: 'File format not supported' } }),
+    } as Response);
+
+    const svc = new ElevenLabsVoiceClone('key-abc');
+    await expect(
+      svc.cloneVoice({ files: [makeFile('a.mp3')], name: 'Test' })
+    ).rejects.toThrow('File format not supported');
+  });
+
+  it('falls back to raw text when error body is not JSON', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      text: async () => 'upstream timeout',
+    } as Response);
+
+    const svc = new ElevenLabsVoiceClone('key-abc');
+    await expect(
+      svc.cloneVoice({ files: [makeFile('a.webm')], name: 'Test' })
+    ).rejects.toThrow('upstream timeout');
+  });
+
+  it('omits description from FormData when not provided', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ voice_id: 'v-789', name: 'NoDesc' }),
+    } as Response);
+
+    const svc = new ElevenLabsVoiceClone('key-abc');
+    await svc.cloneVoice({ files: [makeFile('a.webm')], name: 'NoDesc' });
+
+    const fd = vi.mocked(fetch).mock.calls[0][1]!.body as FormData;
+    expect(fd.get('description')).toBeNull();
+  });
+});

--- a/packages/cloning/lib/elevenlabs-clone.ts
+++ b/packages/cloning/lib/elevenlabs-clone.ts
@@ -9,6 +9,19 @@ interface CloneVoiceResponse {
   name: string;
 }
 
+export interface SimilarVoice {
+  voice_id: string;
+  name: string;
+  category: string;
+  description: string;
+  preview_url: string;
+  similarity_score?: number;
+}
+
+interface SimilarVoicesResponse {
+  voices: SimilarVoice[];
+}
+
 export class ElevenLabsVoiceClone {
   private apiKey: string;
   private baseUrl = 'https://api.elevenlabs.io';
@@ -27,51 +40,68 @@ export class ElevenLabsVoiceClone {
     }
 
     const formData = new FormData();
-    
-    // Add files to FormData
-    files.forEach(file => {
-      formData.append('files', file);
-    });
-
-    // Add name and description
+    files.forEach(file => formData.append('files', file));
     formData.append('name', name);
-    if (description) {
-      formData.append('description', description);
-    }
-
-    // Add labels
+    if (description) formData.append('description', description);
     formData.append('labels', JSON.stringify({ app: 'september' }));
 
-    const url = `${this.baseUrl}/v1/voices/add`;
-
-    const response = await fetch(url, {
+    const response = await fetch(`${this.baseUrl}/v1/voices/add`, {
       method: 'POST',
-      headers: {
-        'xi-api-key': this.apiKey,
-      },
+      headers: { 'xi-api-key': this.apiKey },
       body: formData,
     });
 
     if (!response.ok) {
       const errorText = await response.text();
       let errorMessage = `ElevenLabs API error: ${response.status} ${response.statusText}`;
-      
       try {
         const errorData = JSON.parse(errorText);
         errorMessage = errorData.detail?.message || errorMessage;
       } catch {
         errorMessage = errorText || errorMessage;
       }
-
       throw new Error(errorMessage);
     }
 
     const data = await response.json();
+    return { voice_id: data.voice_id, name: data.name || name };
+  }
 
-    return {
-      voice_id: data.voice_id,
-      name: data.name || name,
-    };
+  /**
+   * Find voices in the ElevenLabs library that sound similar to the provided audio samples.
+   * Uses the voice similarity search endpoint.
+   */
+  async findSimilarVoices(files: File[]): Promise<SimilarVoice[]> {
+    if (!this.apiKey) {
+      throw new Error('ElevenLabs API key is required');
+    }
+
+    if (files.length === 0) {
+      throw new Error('At least one audio file is required');
+    }
+
+    const formData = new FormData();
+    files.forEach(file => formData.append('audio_samples', file));
+
+    const response = await fetch(`${this.baseUrl}/v1/voices/similar`, {
+      method: 'POST',
+      headers: { 'xi-api-key': this.apiKey },
+      body: formData,
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      let errorMessage = `ElevenLabs API error: ${response.status} ${response.statusText}`;
+      try {
+        const errorData = JSON.parse(errorText);
+        errorMessage = errorData.detail?.message || errorMessage;
+      } catch {
+        errorMessage = errorText || errorMessage;
+      }
+      throw new Error(errorMessage);
+    }
+
+    const data: SimilarVoicesResponse = await response.json();
+    return data.voices ?? [];
   }
 }
-

--- a/packages/cloning/lib/media-recorder-manager.ts
+++ b/packages/cloning/lib/media-recorder-manager.ts
@@ -1,0 +1,107 @@
+/**
+ * MediaRecorderManager
+ *
+ * Plain-TS class (no React) that manages per-sample MediaRecorder lifecycle.
+ * Testable without React fiber. useMediaRecorder wraps this with useState.
+ *
+ * Design decisions:
+ *  - Map<id, {recorder, stream}> — stop(id) affects exactly that recording.
+ *  - Starting a new recording for an ID while one is already running stops
+ *    the previous one first (cleans up its stream).
+ *  - stopAll() is called on React unmount to release the microphone.
+ */
+
+import { RecordingStatus } from '@september/cloning/types';
+
+export type { RecordingStatus };
+
+export interface RecordingEntry {
+  recorder: MediaRecorder;
+  stream: MediaStream;
+}
+
+export type OnComplete = (id: string, blob: Blob) => void;
+export type OnStatusChange = (id: string, status: RecordingStatus) => void;
+export type OnError = (id: string, error: string) => void;
+
+export class MediaRecorderManager {
+  private active = new Map<string, RecordingEntry>();
+  private onComplete: OnComplete | null = null;
+  private onStatusChange: OnStatusChange | null = null;
+  private onError: OnError | null = null;
+
+  setCallbacks(cbs: {
+    onComplete?: OnComplete;
+    onStatusChange?: OnStatusChange;
+    onError?: OnError;
+  }) {
+    if (cbs.onComplete) this.onComplete = cbs.onComplete;
+    if (cbs.onStatusChange) this.onStatusChange = cbs.onStatusChange;
+    if (cbs.onError) this.onError = cbs.onError;
+  }
+
+  async startRecording(id: string): Promise<void> {
+    // Mic is exclusive — stop every active recording before acquiring the stream.
+    for (const activeId of [...this.active.keys()]) {
+      this.stopEntry(activeId);
+    }
+
+    let stream: MediaStream;
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    } catch (err) {
+      this.onStatusChange?.(id, 'error');
+      this.onError?.(id, err instanceof Error ? err.message : 'Microphone access denied');
+      return;
+    }
+
+    const chunks: BlobPart[] = [];
+    const recorder = new MediaRecorder(stream);
+
+    recorder.ondataavailable = e => {
+      if (e.data.size > 0) chunks.push(e.data);
+    };
+
+    recorder.onstop = () => {
+      this.active.delete(id);
+      stream.getTracks().forEach(t => t.stop());
+
+      const blob = new Blob(chunks, { type: 'audio/webm' });
+      this.onComplete?.(id, blob);
+    };
+
+    recorder.onerror = () => {
+      this.active.delete(id);
+      stream.getTracks().forEach(t => t.stop());
+      this.onStatusChange?.(id, 'error');
+      this.onError?.(id, 'Recording error occurred');
+    };
+
+    this.active.set(id, { recorder, stream });
+    recorder.start();
+    this.onStatusChange?.(id, 'recording');
+  }
+
+  stopRecording(id: string): void {
+    this.stopEntry(id);
+  }
+
+  stopAll(): void {
+    for (const id of [...this.active.keys()]) {
+      this.stopEntry(id);
+    }
+  }
+
+  private stopEntry(id: string): void {
+    const entry = this.active.get(id);
+    if (!entry) return;
+
+    // Remove before stopping to avoid re-entrant onstop calls
+    this.active.delete(id);
+    entry.stream.getTracks().forEach(t => t.stop());
+
+    if (entry.recorder.state !== 'inactive') {
+      entry.recorder.stop();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes three P1 bugs that made voice cloning silently broken for any real audio, plus P2 correctness issues, plus ships the `/voices?search=similar` route.

**P1 fixes**
- **Stack overflow on upload** — `uploadAudio()` used `btoa(String.fromCharCode(...new Uint8Array(buf)))`, which blows V8's call-stack on any file >~65 KB. Added `AudioService.uploadAudioBinary(Blob | ArrayBuffer)` that stores binary directly. All cloning callers migrated. Legacy base64 path kept for TTS/chats.
- **Mic stream leak** — `useMediaRecorder` kept a single shared recorder ref, so switching samples silently dropped the old stream reference and left the mic indicator lit. Extracted `MediaRecorderManager` (plain TS, no React) with `Map<id,{recorder,stream}>`. Mic is exclusive — `startRecording()` stops all active entries first. `stopAll()` called on unmount.
- **Blob URL memory leak** — `useAudioPlayback` created object URLs but never revoked them. Rewrote to own the full create/revoke lifecycle (revoke on `ended`, `error`, `stopPlaying`).

**P2 fixes**
- **Mixed sources dropped** — `form.tsx` used a ternary (uploads OR recordings, never both). Replaced with `collectSampleIds()` that merges + dedupes.
- **4× AudioService instances** — hoisted single `useVoiceStorage` into `CloningProvider`.
- **Post-clone cleanup** — `deleteVoiceSample()` called after successful clone to release IndexedDB.

**Lane C**
- New `/voices?search=similar` route: loads stored samples, submits to ElevenLabs `/v1/voices/similar`, displays library voices ranked by similarity with inline preview. Auto-triggers when the user has samples.

## Test plan

- [x] `pnpm --filter @september/audio test` — 12/12 green (5 new regression tests including 1 MB blob round-trip)
- [x] `pnpm --filter @september/cloning test` — 18/18 green (regression coverage for mic leak, unmount cleanup, ternary drop, all ElevenLabs paths)
- [x] `pnpm --filter @september/web exec tsc --noEmit` — clean
- [ ] Manually record 3 samples on `/clone`, submit, confirm ElevenLabs returns a `voice_id`
- [ ] Upload a 5 MB MP3 on `/clone`, confirm no stack overflow
- [ ] Switch between recording samples rapidly, confirm mic indicator turns off when stopped
- [ ] Navigate away mid-recording, confirm mic releases (check OS mic indicator)
- [ ] Hit `/voices?search=similar` with existing samples, confirm results render with previews